### PR TITLE
Fix chmod on local path for non-root installs

### DIFF
--- a/installer/docker-install-master
+++ b/installer/docker-install-master
@@ -18,7 +18,7 @@ print("[INITALIZING taskcat Installer!!]")
 linux_install = '''
 INSTALL_DIR='/usr/local/bin'
 
-if [[ -d $HOME/.aws ]]; then 
+if [ -d $HOME/.aws ]; then 
  	echo "[INFO] : Found boto profile)"
  	echo "[INFO] : Boto profile will map to container during execution"
 	echo "echo \"[dockerize]\"" >taskcat.docker
@@ -29,7 +29,7 @@ else
 
 fi
 
-if [[ $(id -u) -eq 0  ]] ;
+if [ $(id -u) -eq 0  ] ;
 then 
         docker pull taskcat/taskcat
         sudo mv taskcat.docker ${INSTALL_DIR}/taskcat

--- a/installer/docker-install-master
+++ b/installer/docker-install-master
@@ -40,7 +40,7 @@ then
 else 
         docker pull taskcat/taskcat
         mv taskcat.docker taskcat
-	chmod 755 ${INSTALL_DIR}/taskcat
+	chmod 755 taskcat
         echo '\n\t[taskcat] INSTALL COMPLETE'
         echo '\t[i] Root previlages were not provied!'
         echo '\t[i] taskcat is installed in => ' $(pwd)


### PR DESCRIPTION
Current code tries a chmod on /usr/local/bin even for non-root users which fails with `chmod: cannot access '/usr/local/bin/taskcat': No such file or directory`