### PR TITLE
Fixing S3 Prefix fuzzy validation

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -402,7 +402,7 @@ class TaskCat(object):
         bucket_location = s3_client.get_bucket_location(
             Bucket=self.get_s3bucket())
         _project_s3_prefix = self.get_project()
-        result = s3_client.list_objects(Bucket=self.get_s3bucket(), Prefix=_s3_prefix)
+        result = s3_client.list_objects(Bucket=self.get_s3bucket(), Prefix=_project_s3_prefix)
         contents = result.get('Contents')
         for s3obj in contents:
             for metadata in s3obj.items():


### PR DESCRIPTION
See: https://github.com/aws-quickstart/taskcat/issues/36
Similar to (36), the only debugging statements are:
```
foo.append(terms)
```
//////

Again, examples are sanitized, but proof the PR works. 

```python
>>> for s3obj in contents:
...     for metadata in s3obj.items():                                                                                                                                          
...             if metadata[0] == 'Key':
...                     # Finding exact match
...                     terms = metadata[1].split("/")
...                     _found_prefix = terms[0]                                                                                                                                
...                     if (key == terms[-1]) and (_found_prefix == _project_s3_prefix):
...                             foo.append(terms)
... 
>>> foo
 [['example', 'LICENSE.txt']]
```

