### PR TITLE
adds support to run cf templates with CAPABILITY_NAMED_IAM

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -916,7 +916,7 @@ class TaskCat(object):
 
         """
         testdata_list = []
-        self.set_capabilities('CAPABILITY_IAM')
+        self.set_capabilities('CAPABILITY_NAMED_IAM')
         for test in test_list:
             testdata = TestData()
             testdata.set_test_name(test)


### PR DESCRIPTION
Needed if you want to create IAM with custom named resources. Resolves the CF error ``` Requires capabilities : [CAPABILITY_NAMED_IAM]```