### PR TITLE
Handle missing template description in yaml CF templates

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -589,7 +589,7 @@ class TaskCat(object):
                 cfn.validate_template(TemplateURL=self.get_s3_url(self.get_template_file()))
                 result = cfn.validate_template(TemplateURL=self.get_s3_url(self.get_template_file()))
                 print(P + "Validated [%s]" % self.get_template_file())
-                cfn_result = (result['Description'])
+                cfn_result = getattr(result, 'Description', 'No description in - CloudFormation template')
                 print(I + "Description  [%s]" % textwrap.fill(cfn_result))
                 if self.verbose:
                     cfn_params = json.dumps(result['Parameters'], indent=11, separators=(',', ': '))


### PR DESCRIPTION
CloudFormation templates are valid even when no description is given in
the head of the file.

If no description is present the template validation will fail.

This change only prints the template description if present, otherwise
will fall back to a default template description.