### PR TITLE
Fix for Fuzzy Matches in buildmap func.

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -95,7 +95,7 @@ def get_pip_version(pkginfo_url):
             return (current_version[1]).strip()
 
 
-def buildmap(start_location, map_string):
+def buildmap(start_location, map_string, partial_match=True):
     """
     Given a start location and a string value, this function returns a list of
     file paths containing the given string value, down in the directory
@@ -103,9 +103,12 @@ def buildmap(start_location, map_string):
 
     :param start_location: directory from where to start looking for the file
     :param map_string: value to match in the file path
+    :param partial_match: (bool) Turn on partial matching.  Ex: 'foo' matches 'foo' and 'foo.old'. Defaults true. False adds a '/' to the end of the string.
     :return:
         list of file paths containing the given value.
     """
+    if not partial_match:
+        map_string = "{}/".format(map_string)
     fs_map = []
     for fs_path, dirs, filelist in os.walk(start_location, topdown=False):
         for fs_file in filelist:
@@ -398,7 +401,7 @@ class TaskCat(object):
         # TODO Remove after alchemist is implemented
 
         if os.path.isdir(self.get_project()):
-            fsmap = buildmap('.', self.get_project())
+            fsmap = buildmap('.', self.get_project(), partial_match=False)
         else:
 
             print('''\t\t Hint: The name specfied as value of qsname ({})


### PR DESCRIPTION
See #60 

Pudb debugging: 

```
>>> pprint(fsmap)                                                                                                                                                           
['./quickstart-linux-bastion/ci/taskcat_project_override.json',
(...)
 './quickstart-linux-bastion/NOTICE.txt',
 './quickstart-linux-bastion/LICENSE.txt']

>>> for fn in fsmap:
...   if '.old' in fn:
...    print fn
... 
>>> 
```

Original debugging from issue; over here for ease of use. 

pudb debugging: 
```
>>> pprint(fsmap)
(...)
 './quickstart-linux-bastion/README.md',
 './quickstart-linux-bastion/NOTICE.txt',
 './quickstart-linux-bastion/LICENSE.txt',
 './quickstart-linux-bastion.old/templates/linux-bastion.template',
 './quickstart-linux-bastion.old/templates/linux-bastion-master.template',
 './quickstart-linux-bastion.old/scripts/bastion_bootstrap.sh',
 './quickstart-linux-bastion.old/scripts/banner_message.txt',
 './quickstart-linux-bastion.old/README.md',
 './quickstart-linux-bastion.old/NOTICE.txt',
 './quickstart-linux-bastion.old/LICENSE.txt']

```