### PR TITLE
Updated default source bucket value

### DIFF
--- a/taskcat/deployer.py
+++ b/taskcat/deployer.py
@@ -82,7 +82,7 @@ class CFNAlchemist(object):
         self._excluded_prefixes = None
         self._verbose = False
         self._dry_run = False
-        self._prod_bucket_name = 'quickstart-reference'
+        self._prod_bucket_name = 'aws-quickstart'
         self._default_region = 'us-east-1'
         self._file_list = None
 


### PR DESCRIPTION
As per seller guide https://aws-quickstart.github.io/design-parms.html#qsconfig
the default has now changed from "quickstart-reference" to "aws-quickstart"
TrendMicro has already moved to using the new value https://github.com/aws-quickstart/quickstart-trendmicro-deepsecurity/blob/master/templates/quickstart/trendmicro-deepsecurity-master.template#L119
