### PR TITLE
add linting support

### DIFF
--- a/taskcat.py
+++ b/taskcat.py
@@ -43,10 +43,10 @@ def main():
             taskcat_cfg = yaml.safe_load(cfg.read())
         cfg.close()
 
-        project_path = '/'.join(tcat_instance.get_config().split('/')[0:-2])
-        os.chdir(os.path.abspath(project_path))
-        tcat_instance.lint(args.lint)
-        os.chdir(os.path.abspath('../'))
+        project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
+        if project_path:
+            os.chdir(os.path.abspath(project_path))
+        tcat_instance.lint(args.lint, path='/'.join(tcat_instance.get_config().split('/')[-3:-2]))
         tcat_instance.stage_in_s3(taskcat_cfg)
         tcat_instance.validate_template(taskcat_cfg, test_list)
         tcat_instance.validate_parameters(taskcat_cfg, test_list)

--- a/taskcat.py
+++ b/taskcat.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 import taskcat
 import yaml
 import sys
+import os
 
 if sys.version_info[0] < 3:
     raise Exception("Please use Python 3")
@@ -42,6 +43,10 @@ def main():
             taskcat_cfg = yaml.safe_load(cfg.read())
         cfg.close()
 
+        project_path = '/'.join(tcat_instance.get_config().split('/')[0:-2])
+        os.chdir(os.path.abspath(project_path))
+        tcat_instance.lint(args.lint)
+        os.chdir(os.path.abspath('../'))
         tcat_instance.stage_in_s3(taskcat_cfg)
         tcat_instance.validate_template(taskcat_cfg, test_list)
         tcat_instance.validate_parameters(taskcat_cfg, test_list)

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1722,8 +1722,92 @@ class TaskCat(object):
             return False
         return True
 
+    def lint(self, strict='warn'):
+        """
+        Lints all templates (against each region to be tested) using cfn_python_lint
 
+        :param strict: string, "error" outputs a log line for each warning and fails on errors, if set to "strict"
+        will exit on warnings and failures, if set to "warn" will only output warnings for errors
+        :return:
+        """
+        if strict not in ['error', 'strict', 'warn']:
+            print(E + "lint was set to an invalid value '%s', valid values are: 'error', 'strict', 'warn'" % strict)
+            sys.exit(1)
+        lints = {}
+        templates = {}
+        config = yaml.safe_load(open(self.config))
+        rules = cfnlint.core.get_rules([], [])
+        for test in config['tests'].keys():
+            lints[test] = {}
+            if 'regions' in config['tests'][test].keys():
+                lints[test]['regions'] = config['tests'][test]['regions']
+            else:
+                lints[test]['regions'] = config['global']['regions']
+            template_file = config['tests'][test]['template_file']
+            template_file = 'templates/' + template_file
+            lints[test]['template_file'] = template_file
+            if template_file not in templates.keys():
+                templates[template_file] = self.get_child_templates(template_file)
+            lints[test]['results'] = {}
+            templates[template_file].add(template_file)
+            for t in templates[template_file]:
+                template = cfnlint.decode.cfn_yaml.load(t)
+                lints[test]['results'][t] = cfnlint.core.run_checks(
+                    t,
+                    template,
+                    rules,
+                    lints[test]['regions'])
+        test_status = {"W": False, "E": False}
+        for test in lints.keys():
+            for t in lints[test]['results'].keys():
+                print(I + "Lint results for test %s on template %s:" % (test, t))
+                for r in lints[test]['results'][t]:
+                    message = r.__str__().lstrip('[')
+                    sev = message[0]
+                    if sev == 'E':
+                        print(E + "    " + message)
+                        test_status[sev] = True
+                    elif sev == 'W':
+                        if 'E' + message[1:] not in [r.__str__().lstrip('[') for r in lints[test]['results'][t]]:
+                            print(I + "    " + message)
+                            test_status[sev] = True
+                    else:
+                        print(D + "linter produced unkown output: " + message)
+        if strict in ['error', 'strict'] and test_status['E']:
+            print(F + "Exiting due to lint errors")
+            sys.exit(1)
+        elif strict == 'strict' and test_status['W']:
+            print(F + "Exiting due to lint warnings")
+            sys.exit(1)
 
+    def get_child_templates(self, filename):
+        """
+        recursively find nested templates given a template path
+
+        :param filename: string, path to template
+        :return: set of nested template paths
+        """
+        children = set()
+        template = cfnlint.decode.cfn_yaml.load(filename)
+        for resource in template['Resources'].keys():
+            child_name = ''
+            if template['Resources'][resource]['Type'] == "AWS::CloudFormation::Stack":
+                template_url = template['Resources'][resource]['Properties']['TemplateURL']
+                if type(template_url) == dict:
+                    if 'Fn::Sub' in template_url.keys():
+                        if type(template_url['Fn::Sub']) == str:
+                            child_name = template_url['Fn::Sub'].split('}')[-1]
+                        else:
+                            child_name = template_url['Fn::Sub'][0].split('}')[-1]
+                    elif 'Fn::Join' in template_url.keys()[0]:
+                        child_name = template_url['Fn::Join'][1][-1]
+                elif type(template_url) == str:
+                    if 'submodules/' not in template_url:
+                        child_name = '/'.join(template_url.split('/')[-2:])
+            if child_name and not child_name.startswith('submodules/'):
+                children.add(child_name)
+                children.union(self.get_child_templates(child_name))
+        return children
 
     # Set AWS Credentials
     # Set AWS Credentials
@@ -2260,6 +2344,13 @@ class TaskCat(object):
             type=str,
             default="tag",
             help="set prefix for cloudformation stack name. only accepts lowercase letters, numbers and '-'")
+        parser.add_argument(
+            '-l',
+            '--lint',
+            type=str,
+            default="warn",
+            help="set linting 'strict' - will fail on errors and warnings, 'error' will fail on errors or 'warn' will "
+                 "log errors to the console, but not fail")
         args = parser.parse_args()
 
         if len(sys.argv) == 1:


### PR DESCRIPTION
initial stab at adding linting support to taskcat.

By default only warns, to prevent changing any existing behaviors. set `-l error` to fail on errors and `-l strict` to fail on warnings as well.