### PR TITLE
Fix region exception when AWS_DEFAULT_REGION not set

### DIFF
--- a/bin/taskcat
+++ b/bin/taskcat
@@ -23,42 +23,45 @@ if sys.version_info[0] < 3:
 
 
 def main():
-    tcat_instance = taskcat.TaskCat()
-    args = tcat_instance.interface
-    tcat_instance.welcome('taskcat')
-    # Initialize cli interface
-    # :TODO Add RestFull Interface
+    try:
+        tcat_instance = taskcat.TaskCat()
+        args = tcat_instance.interface
+        tcat_instance.welcome('taskcat')
+        # Initialize cli interface
+        # :TODO Add RestFull Interface
 
-    # Get configuration from command line arg (-c)
-    tcat_instance.set_config(args.config_yml)
-    # tcat_instance.set_config('ci/config.yml')
-    # Get API Handle - Try all know auth
-    tcat_instance.aws_api_init(args)
-    # Optional: Enables verbose output by default (DEBUG ON)
-    tcat_instance.verbose = True
-# --Begin
-# Check for valid ymal and required keys in config
-    if args.config_yml is not None:
+        # Get configuration from command line arg (-c)
+        tcat_instance.set_config(args.config_yml)
+        # tcat_instance.set_config('ci/config.yml')
+        # Get API Handle - Try all know auth
+        tcat_instance.aws_api_init(args)
+        # Optional: Enables verbose output by default (DEBUG ON)
+        tcat_instance.verbose = True
+    # --Begin
+    # Check for valid ymal and required keys in config
+        if args.config_yml is not None:
 
-        test_list = tcat_instance.validate_yaml(args.config_yml)
+            test_list = tcat_instance.validate_yaml(args.config_yml)
 
-# Load yaml into local taskcat config
-        with open(tcat_instance.get_config(), 'r') as cfg:
-            taskcat_cfg = yaml.safe_load(cfg.read())
-        cfg.close()
+    # Load yaml into local taskcat config
+            with open(tcat_instance.get_config(), 'r') as cfg:
+                taskcat_cfg = yaml.safe_load(cfg.read())
+            cfg.close()
 
-        try:
-            project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
-            if project_path:
-                os.chdir(os.path.abspath(project_path))
-                tcat_instance.lint(args.lint, path='/'.join(tcat_instance.get_config().split('/')[-3:-2]))
-        except Exception as e:
-            print("ERROR: Linting failed: %s" % e)
-            if args.lint in ['error', 'strict']:
-                raise
-            else:
-                traceback.print_exc()
-        try:
+            try:
+                project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
+                if project_path:
+                    os.chdir(os.path.abspath(project_path))
+                    tcat_instance.lint(args.lint, path='/'.join(tcat_instance.get_config().split('/')[-3:-2]))
+            except taskcat.exceptions.TaskCatException as e:
+                print(taskcat.PrintMsg.ERROR + str(e))
+                exit1(str(e))
+            except Exception as e:
+                print("ERROR: Linting failed: %s" % e)
+                if args.lint in ['error', 'strict']:
+                    raise
+                else:
+                    traceback.print_exc()
             tcat_instance.stage_in_s3(taskcat_cfg)
             tcat_instance.validate_template(taskcat_cfg, test_list)
             tcat_instance.validate_parameters(taskcat_cfg, test_list)
@@ -67,9 +70,9 @@ def main():
             tcat_instance.get_stackstatus(testdata, 5)
             tcat_instance.createreport(testdata, 'index.html')
             tcat_instance.cleanup(testdata, 5)
-        except taskcat.exceptions.TaskCatException as e:
-            print(taskcat.PrintMsg.ERROR + str(e))
-            exit1(str(e))
+    except taskcat.exceptions.TaskCatException as e:
+        print(taskcat.PrintMsg.ERROR + str(e))
+        exit1(str(e))
 
 # --End
 

--- a/taskcat/client_factory.py
+++ b/taskcat/client_factory.py
@@ -112,7 +112,10 @@ class ClientFactory(object):
                 credential_set]
         if not region:
             self.logger.debug("Region not set explicitly, getting default region")
-            region = os.environ['AWS_DEFAULT_REGION']
+            region = os.environ.get('AWS_DEFAULT_REGION')
+            if not region:
+                self.logger.warning("Region not set in environment, defaulting to us-east-1")
+                region = 'us-east-1'
         s3v4 = 's3v4' if s3v4 else 'default_sig_version'
         try:
             self.logger.debug("Trying to get [%s][%s][%s][%s]" % (credential_set, region, service, s3v4))
@@ -253,6 +256,9 @@ class ClientFactory(object):
         """
         if not region:
             self.logger.debug("Region not set explicitly, getting default region")
-            region = os.environ['AWS_DEFAULT_REGION']
+            region = os.environ.get('AWS_DEFAULT_REGION')
+            if not region:
+                self.logger.warning("Region not set in environment, defaulting to us-east-1")
+                region = 'us-east-1'
 
         return self._clients[credential_set][region]['session']

--- a/taskcat/common_utils.py
+++ b/taskcat/common_utils.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 
 class CommonTools:
@@ -36,8 +37,10 @@ class CommonTools:
         stack_info['stack_name'] = self.regxfind(stack_name_re, self.stack_name)
         return stack_info
 
-def exit1(msg):
+
+def exit1(msg=''):
     sys.exit(1)
 
-def exit0(msg):
+
+def exit0(msg=''):
     sys.exit(0)

--- a/taskcat/common_utils.py
+++ b/taskcat/common_utils.py
@@ -26,7 +26,6 @@ class CommonTools:
         """
         Returns a dictionary object containing the region and stack name.
 
-        :param stack_name: Full stack name arn
         :return: Dictionary object containing the region and stack name
 
         """

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1756,7 +1756,7 @@ class TaskCat(object):
         """
         print('\n')
 
-        self.set_default_region = ClientFactory().get_default_region(args.aws_access_key, args.aws_secret_key, None, args.boto_profile)
+        self.set_default_region(region=ClientFactory().get_default_region(args.aws_access_key, args.aws_secret_key, None, args.boto_profile))
         if args.boto_profile:
             self._auth_mode = 'profile'
             self._boto_profile = args.boto_profile

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1755,6 +1755,13 @@ class TaskCat(object):
             either profile name, access key and secret key or none.
         """
         print('\n')
+
+        ## TODO: look for region in profile/cli config as well
+        if os.environ.get('AWS_DEFAULT_REGION'):
+            self.set_default_region(os.environ.get('AWS_DEFAULT_REGION'))
+            print(PrintMsg.INFO + "Using environmental region set in $AWS_DEFAULT_REGION")
+        else:
+            self.set_default_region('us-east-1')
         if args.boto_profile:
             self._auth_mode = 'profile'
             self._boto_profile = args.boto_profile
@@ -1793,11 +1800,6 @@ class TaskCat(object):
                     print(PrintMsg.DEBUG + str(e))
         else:
             self._auth_mode = 'environment'
-            if os.environ.get('AWS_DEFAULT_REGION'):
-                self.set_default_region(os.environ.get('AWS_DEFAULT_REGION'))
-                print(PrintMsg.INFO + "Using environmental region set in $AWS_DEFAULT_REGION")
-            else:
-                self.set_default_region('us-east-1')
 
             try:
                 sts_client = self._boto_client.get('sts',

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1756,12 +1756,7 @@ class TaskCat(object):
         """
         print('\n')
 
-        ## TODO: look for region in profile/cli config as well
-        if os.environ.get('AWS_DEFAULT_REGION'):
-            self.set_default_region(os.environ.get('AWS_DEFAULT_REGION'))
-            print(PrintMsg.INFO + "Using environmental region set in $AWS_DEFAULT_REGION")
-        else:
-            self.set_default_region('us-east-1')
+        self.set_default_region = ClientFactory().get_default_region(args.aws_access_key, args.aws_secret_key, None, args.boto_profile)
         if args.boto_profile:
             self._auth_mode = 'profile'
             self._boto_profile = args.boto_profile


### PR DESCRIPTION
## Overview

Fixes #136

## Testing/Steps taken to ensure quality

Ran `python setup.py test`

invoked taskcat using the `--profile` argument

### Notes

Also threw in a [commit](https://github.com/aws-quickstart/taskcat/commit/1d849626c8d900296f33aab6aba75ee190701530) that fixes a bug that prevented taskcat from exiting cleanly when `exit0` or `exit1` were called.

## Testing Instructions

run taskcat using the `--profile` argument and AWS_DEFAULT_REGION not set as an environment variable.
