### PR TITLE
Fix retain if failed

### DIFF
--- a/taskcat/generate_reports.py
+++ b/taskcat/generate_reports.py
@@ -13,11 +13,12 @@ class ReportBuilder:
 
     """
 
-    def __init__(self, test_data, dashboard_filename, version, boto_client):
+    def __init__(self, test_data, dashboard_filename, version, boto_client, taskcat):
         self.dashboard_filename = dashboard_filename
         self.test_data = test_data
         self.version = version
         self._boto_client = boto_client
+        self.taskcat = taskcat
 
     def generate_report(self):
         doc = yattag.Doc()
@@ -46,8 +47,8 @@ class ReportBuilder:
                         status_css = 'class=test-green'
                     elif rstatus == 'CREATE_FAILED':
                         status_css = 'class=test-red'
-                        if self.retain_if_failed and (self.run_cleanup == True):
-                            self.run_cleanup = False
+                        if self.taskcat.retain_if_failed and (self.taskcat.run_cleanup == True):
+                            self.taskcat.run_cleanup = False
                     else:
                         status_css = 'class=test-red'
             except TaskCatException:

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1925,7 +1925,7 @@ class TaskCat(object):
         cfn_logs.createcfnlogs(testdata_list, o_directory)
 
         # Generate html test dashboard
-        cfn_report = ReportBuilder(testdata_list, dashboard_filename, self.version, self._boto_client)
+        cfn_report = ReportBuilder(testdata_list, dashboard_filename, self.version, self._boto_client, self)
         cfn_report.generate_report()
 
     @property

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -77,7 +77,7 @@ Given the url to PypI package info url returns the current live version
 
 # create logger
 logger = logging.getLogger('taskcat')
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.ERROR)
 
 
 def get_pip_version(url):


### PR DESCRIPTION
## Overview

fix error when retain stacks is enabled

```
[ERROR  ] :Error describing stack named [tCaT-tag-openshift-62076d8e]
[DEBUG  ] :'ReportBuilder' object has no attribute 'retain_if_failed'
```

## Testing/Steps taken to ensure quality

ran taskcat against a failing stack with retain enabled


