### PR TITLE
Updated boto/botocore to patch 21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools==40.0.0
 mock==2.0.0
-boto3==1.9.16
-botocore==1.12.16
+boto3==1.9.21
+botocore==1.12.21
 cfnlint==0.0.9
 pyfiglet==0.7.5
 tabulate==0.8.2


### PR DESCRIPTION
## Overview

This PR updates boto3 to 1.9.21 and botocore to 1.12.21 to be in line with the latest released awscli.
Currently when you have both the awscli and taskcat installed in the same virtualenv, their requirements conflict.

## Testing/Steps taken to ensure quality

Ran the unit tests, which only produced deprecation warnings

### Notes

None

## Testing Instructions

None