### PR TITLE
sync with S3

### DIFF
--- a/taskcat/__init__.py
+++ b/taskcat/__init__.py
@@ -7,3 +7,4 @@ from taskcat.reaper import *
 from taskcat.utils import *
 from taskcat.client_factory import ClientFactory
 from taskcat.exceptions import TaskCatException
+from taskcat.s3_sync import S3Sync

--- a/taskcat/s3_sync.py
+++ b/taskcat/s3_sync.py
@@ -38,7 +38,7 @@ class S3Sync(object):
         "ci/"
     ]
 
-    def __init__(self, s3_client, bucket, prefix, path, acl=None):
+    def __init__(self, s3_client, bucket, prefix, path, acl="private"):
         """Syncronizes local file system with an s3 bucket/prefix
 
         """

--- a/taskcat/s3_sync.py
+++ b/taskcat/s3_sync.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# authors:
+# Tony Vattathil <tonynv@amazon.com>, <avattathil@gmail.com>
+# Santiago Cardenas <sancard@amazon.com>, <santiago[dot]cardenas[at]outlook[dot]com>
+# Shivansh Singh <sshvans@amazon.com>,
+# Jay McConnell <jmmccon@amazon.com>,
+# Andrew Glenn <andglenn@amazon.com>
+from __future__ import print_function
+
+import hashlib
+import fnmatch
+import os
+import time
+from functools import partial
+from multiprocessing.dummy import Pool as ThreadPool
+from taskcat.colored_console import PrintMsg
+
+
+class S3Sync(object):
+    """Syncronizes local project files with S3 based on checksums.
+
+    Excludes hidden files, unpackaged lambda source and taskcat /ci/ files.
+    Uses the Etag as an md5 which introduces the following limitations
+        * Uses undocumented etag algorithm for multipart uploads
+        * Does not work wil files uploaded in the console that use SSE encryption
+        * see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html for more info
+    Does not support buckets with versioning enabled
+    """
+
+    _exclude_files = [
+        ".*",
+        "*.md"
+    ]
+    _exclude_path_prefixes = [
+        "functions/source/",
+        ".",
+        "ci/"
+    ]
+
+    def __init__(self, s3_client, bucket, prefix, path, acl=None):
+        """Syncronizes local file system with an s3 bucket/prefix
+
+        """
+        if prefix != "" and not prefix.endswith('/'):
+            prefix = prefix + '/'
+        self.s3_client = s3_client
+        fl = self._get_local_file_list(path)
+        s3fl = self._get_s3_file_list(bucket, prefix)
+        self._sync(fl, s3fl, bucket, prefix, acl=acl)
+        return
+
+    def _hash_file(self, file_path, chunk_size=8 * 1024 * 1024):
+        # This is a bit funky because of the way multipart upload etags are done, they are a md5 of the md5's from each part with the number of parts appended
+        # credit to hyperknot https://github.com/aws/aws-cli/issues/2585#issue-226758933
+        md5s = []
+
+        with open(file_path, 'rb') as fp:
+            while True:
+                data = fp.read(chunk_size)
+                if not data:
+                    break
+                md5s.append(hashlib.md5(data))
+
+        if len(md5s) == 1:
+            return '"{}"'.format(md5s[0].hexdigest())
+
+        digests = b''.join(m.digest() for m in md5s)
+        digests_md5 = hashlib.md5(digests)
+        return '"{}-{}"'.format(digests_md5.hexdigest(), len(md5s))
+
+    def _get_local_file_list(self, path, include_checksums=True):
+        file_list = []
+        path = os.path.abspath(os.path.expanduser(path))
+        for root, dirs, files in os.walk(path):
+            relpath = os.path.relpath(root, path) + "/"
+            exclude_path = False
+            if relpath == './':
+                relpath = ""
+            for p in S3Sync._exclude_path_prefixes:
+                if relpath.startswith(p):
+                    exclude_path = True
+                    break
+            if not exclude_path:
+                for file in files:
+                    exclude = False
+                    for p in S3Sync._exclude_files:
+                        if fnmatch.fnmatch(file, p):
+                            exclude = True
+                            break
+                    if not exclude:
+                        full_path = root + "/" + file
+                        if include_checksums:
+                            checksum = self._hash_file(full_path)
+                        else:
+                            checksum = ""
+                        file_list.append([full_path, relpath + file, checksum])
+        return file_list
+
+    def _get_s3_file_list(self, bucket, prefix):
+        objects = []
+        more_objects = True
+        continuation_token = None
+        while more_objects:
+            if not continuation_token:
+                resp = self.s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+            else:
+                resp = self.s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix, ContinuationToken=continuation_token)
+            if 'Contents' in resp:
+                objects += [[i['Key'][len(prefix):], i['ETag']] for i in resp['Contents']]
+            if 'NextContinuationToken' in resp.keys():
+                continuation_token = resp['NextContinuationToken']
+            else:
+                more_objects = False
+        return objects
+
+    def _sync(self, local_list, s3_list, bucket, prefix, acl, threads=16):
+        # determine which files to remove from S3
+        remove_from_s3 = []
+        for s3f in s3_list:
+            remove = True
+            for f in local_list:
+                if s3f[0] == f[1]:
+                    remove = False
+                    break
+            if remove:
+                remove_from_s3.append({"Key": prefix + s3f[0]})
+        # deleting objects, max 1k objects per s3 delete_objects call
+        for d in [remove_from_s3[i:i + 1000] for i in range(0, len(remove_from_s3), 1000)]:
+            self.s3_client.delete_objects(Bucket=bucket, Delete={'Objects': d})
+        # build list of files to upload
+        upload_to_s3 = []
+        for f in local_list:
+            upload = True
+            for s3f in s3_list:
+                if s3f[0] == f[1] and s3f[1] == f[2]:
+                    upload = False
+            if upload:
+                upload_to_s3.append([f[0], bucket, f[1]])
+        pool = ThreadPool(threads)
+        func = partial(self._s3_upload_file, prefix=prefix, s3_client=self.s3_client, acl=acl)
+        pool.map(func, upload_to_s3)
+        pool.close()
+        pool.join()
+
+    def _s3_upload_file(self, paths, prefix, s3_client, acl):
+        local_filename, bucket, s3_path = paths
+        retry = 0
+        while retry < 5:
+            try:
+                s3_client.upload_file(local_filename, bucket, prefix + s3_path, ExtraArgs={'ACL': acl})
+                print("{}[S3: -> ]{} s3://{}/{}".format(PrintMsg.white, PrintMsg.rst_color, bucket, prefix + s3_path))
+                break
+            except Exception as e:
+                retry += 1
+                time.sleep(retry * 2)
+                print(PrintMsg.ERROR + "S3 upload error: %s" % e)

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1043,7 +1043,7 @@ class TaskCat(object):
                             Tags=self.tags
                         )
                         print(PrintMsg.INFO + "|CFN Execution mode [create_stack]")
-                    except cfn.ecxeptions.ClientError as e:
+                    except cfn.exceptions.ClientError as e:
                         if not str(e).endswith('cannot be used with templates containing Transforms.'):
                             raise
                         print(PrintMsg.INFO + "|CFN Execution mode [change_set]")

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -39,8 +39,6 @@ from argparse import RawTextHelpFormatter
 from botocore.vendored import requests
 
 from pkg_resources import get_distribution
-from functools import partial
-from multiprocessing.dummy import Pool as ThreadPool
 
 from taskcat.reaper import Reaper
 from taskcat.client_factory import ClientFactory
@@ -49,7 +47,7 @@ from taskcat.generate_reports import ReportBuilder
 from taskcat.common_utils import CommonTools
 from taskcat.cfn_logutils import CfnLogTools
 from taskcat.exceptions import TaskCatException
-from taskcat.common_utils import exit1
+from taskcat.s3_sync import S3Sync
 from taskcat.common_utils import exit0
 
 
@@ -184,14 +182,15 @@ class TaskCat(object):
         self._boto_profile = None
         self._boto_client = ClientFactory(logger=logger)
         self._key_url_map = {}
-        self.multithread_upload = False
         self.retain_if_failed = False
         self.tags = []
         self.stack_prefix = ''
         self.template_data = None
         self.version = get_installed_version()
+        self.s3_url_prefix = ""
+        self.upload_only = False
 
-    # SETTERS ANPrintMsg.DEBUG GETTERS
+        # SETTERS ANPrintMsg.DEBUG GETTERS
     # ===================
 
     def set_project(self, project):
@@ -199,12 +198,6 @@ class TaskCat(object):
 
     def get_project(self):
         return self.project
-
-    def set_multithread_upload(self, multithread_upload):
-        self.multithread_upload = multithread_upload
-
-    def get_multithread_upload(self):
-        return self.multithread_upload
 
     def set_owner(self, owner):
         self.owner = owner
@@ -409,7 +402,6 @@ class TaskCat(object):
         s3_client = self._boto_client.get('s3', region=self.get_default_region(), s3v4=True)
         self.set_project(taskcat_cfg['global']['qsname'])
 
-        # TODO Update to alchemist upload
         if 's3bucket' in taskcat_cfg['global'].keys():
             self.set_s3bucket(taskcat_cfg['global']['s3bucket'])
             self.set_s3bucket_type('defined')
@@ -450,53 +442,19 @@ class TaskCat(object):
                     Bucket=auto_bucket,
                     Tagging={"TagSet": self.tags}
                 )
-        # TODO Remove after alchemist is implemented
 
         if os.path.isdir(self.get_project()):
-            current_dir = "."
             start_location = "{}/{}".format(".", self.get_project())
-            fsmap = buildmap(current_dir, start_location, partial_match=False)
         else:
-
             print('''\t\t Hint: The name specfied as value of qsname ({})
                     must match the root directory of your project'''.format(self.get_project()))
             print("{0}!Cannot find directory [{1}] in {2}".format(PrintMsg.ERROR, self.get_project(), os.getcwd()))
             raise TaskCatException("Please cd to where you project is located")
 
-        if self.multithread_upload:
-            threads = 16
-            print(PrintMsg.INFO + "Multithread upload enabled, spawning %s threads" % threads)
-            pool = ThreadPool(threads)
-            func = partial(self._s3_upload_file, s3_client=s3_client, bucket_or_object_acl=bucket_or_object_acl)
-            pool.map(func, fsmap)
-            pool.close()
-            pool.join()
-        else:
-            for filename in fsmap:
-                self._s3_upload_file(filename, s3_client=s3_client, bucket_or_object_acl=bucket_or_object_acl)
-
-        paginator = s3_client.get_paginator('list_objects')
-        operation_parameters = {'Bucket': self.get_s3bucket(), 'Prefix': self.get_project()}
-        s3_pages = paginator.paginate(**operation_parameters)
-
-        for s3keys in s3_pages.search('Contents'):
-            print("{}[S3: -> ]{} s3://{}/{}".format(PrintMsg.white, PrintMsg.rst_color, self.get_s3bucket(),
-                                                    s3keys.get('Key')))
-        print("{} |Contents of S3 Bucket {} {}".format(self.nametag, PrintMsg.header, PrintMsg.rst_color))
-
-        print('\n')
-
-    def _s3_upload_file(self, filename, s3_client, bucket_or_object_acl):
-        upload = re.sub('^./', '', filename)
-        try:
-            s3_client.upload_file(filename, self.get_s3bucket(), upload, ExtraArgs={'ACL': bucket_or_object_acl})
-        except TaskCatException:
-            raise
-        except Exception as e:
-            print("Cannot Upload to bucket => %s" % self.get_s3bucket())
-            if self.verbose:
-                print(PrintMsg.DEBUG + str(e))
-            raise TaskCatException("Check that you bucketname is correct")
+        S3Sync(s3_client, self.get_s3bucket(), self.get_project(), start_location, bucket_or_object_acl)
+        self.s3_url_prefix = "https://" + self.get_s3_hostname() + "/" + self.get_project()
+        if self.upload_only:
+            exit0("Upload completed successfully")
 
     def get_available_azs(self, region, count):
         """
@@ -559,45 +517,30 @@ class TaskCat(object):
         key = self._key_url_map[url]
         return self.get_content(self.get_s3bucket(), key)
 
-    def get_s3_url(self, key):
+    def get_contents(self, path):
         """
-        Returns S3 url of a given object.
+        Returns local file contents as a string.
 
-        :param key: Name of the object whose S3 url is being returned
-        :return: S3 url of the given key
+        :param path: URL of the S3 object to return.
+        :return: file contents
+        """
+        with open(path, 'r') as f:
+            data = f.read()
+        return data
+
+    def get_s3_hostname(self):
+        """
+        Returns S3 hostname of target bucket
+        :return: S3 hostname
 
         """
         s3_client = self._boto_client.get('s3', region=self.get_default_region(), s3v4=True)
         bucket_location = s3_client.get_bucket_location(Bucket=self.get_s3bucket())
-        _project_s3_prefix = self.get_project()
-        paginator = s3_client.get_paginator('list_objects')
-        operation_parameters = {'Bucket': self.get_s3bucket(), 'Prefix': _project_s3_prefix}
-        page_iterator = paginator.paginate(**operation_parameters)
-        for page in page_iterator:
-            for s3obj in (page['Contents']):
-                for metadata in s3obj.items():
-                    if metadata[0] == 'Key':
-                        if key in metadata[1]:
-                            # Finding exact match
-                            terms = metadata[1].split("/")
-                            _found_prefix = terms[0]
-                            # issues/
-                            if (key == terms[-1]) and (_found_prefix == _project_s3_prefix):
-                                if bucket_location[
-                                    'LocationConstraint'
-                                ] is not None:
-                                    o_url = "https://s3-{0}.{1}/{2}/{3}".format(
-                                        bucket_location['LocationConstraint'],
-                                        "amazonaws.com",
-                                        self.get_s3bucket(),
-                                        metadata[1])
-                                    self._key_url_map.update({o_url: metadata[1]})
-                                    return o_url
-                                else:
-                                    amzns3 = 's3.amazonaws.com'
-                                    o_url = "https://{1}.{0}/{2}".format(amzns3, self.get_s3bucket(), metadata[1])
-                                    self._key_url_map.update({o_url: metadata[1]})
-                                    return o_url
+        if bucket_location['LocationConstraint'] is not None:
+            hostname = "s3-{0}.{1}".format(bucket_location['LocationConstraint'], "amazonaws.com")
+        else:
+            hostname = "{0}.s3.amazonaws.com".format(self.get_s3bucket())
+        return hostname
 
     def get_global_region(self, yamlcfg):
         """
@@ -610,19 +553,16 @@ class TaskCat(object):
         g_regions = []
         for keys in yamlcfg['global'].keys():
             if 'region' in keys:
+                namespace = 'global'
                 try:
                     iter(yamlcfg['global']['regions'])
-                    namespace = 'global'
                     for region in yamlcfg['global']['regions']:
-                        # print("found region %s" % region)
                         g_regions.append(region)
                         self._use_global = True
-                except TypeError:
-                    print("No regions defined in [%s]:" % namespace)
-                    print("Please correct region defs[%s]:" % namespace)
+                except TypeError as e:
+                    print(PrintMsg.ERROR + "No regions defined in [%s]:" % namespace)
+                    print(PrintMsg.ERROR + "Please correct region defs[%s]:" % namespace)
         return g_regions
-
-
 
     def extract_template_parameters(self):
         """
@@ -651,8 +591,7 @@ class TaskCat(object):
                     print(PrintMsg.DEBUG + "Default region [%s]" % self.get_default_region())
                 cfn = self._boto_client.get('cloudformation', region=self.get_default_region())
 
-                cfn.validate_template(TemplateURL=self.get_s3_url(self.get_template_file()))
-                result = cfn.validate_template(TemplateURL=self.get_s3_url(self.get_template_file()))
+                result = cfn.validate_template(TemplateURL=self.s3_url_prefix + '/templates/' + self.get_template_file())
                 print(PrintMsg.PASS + "Validated [%s]" % self.get_template_file())
                 if 'Description' in result:
                     cfn_result = (result['Description'])
@@ -1077,7 +1016,7 @@ class TaskCat(object):
                 print(PrintMsg.INFO + "Preparing to launch in region [%s] " % region)
                 try:
                     cfn = self._boto_client.get('cloudformation', region=region)
-                    s_parmsdata = self.get_s3contents(self.get_parameter_path())
+                    s_parmsdata = self.get_contents("./" + self.get_project() + "/ci/" + self.get_parameter_file())
                     s_parms = json.loads(s_parmsdata)
                     s_include_params = self.get_param_includes(s_parms)
                     if s_include_params:
@@ -1171,7 +1110,7 @@ class TaskCat(object):
             if self.verbose:
                 print(PrintMsg.DEBUG + "parameter_path = %s" % self.get_parameter_path())
 
-            inputparms = self.get_s3contents(self.get_parameter_path())
+            inputparms = self.get_contents("./" + self.get_project() + "/ci/" + self.get_parameter_file())
             jsonstatus = self.check_json(inputparms)
 
             if self.verbose:
@@ -1489,7 +1428,6 @@ class TaskCat(object):
                 p = yamlc['tests'][test]['parameter_input']
                 n = yamlc['global']['qsname']
                 o = yamlc['global']['owner']
-                b = self.get_s3bucket()
 
                 # Checks if cleanup flag is set
                 # If cleanup is set to 'false' stack will not be deleted after
@@ -1516,15 +1454,12 @@ class TaskCat(object):
                             print(PrintMsg.INFO + " - (Defaulting to cleanup)")
 
                 # Load test setting
-                self.set_s3bucket(b)
                 self.set_project(n)
                 self.set_owner(o)
                 self.set_template_file(t)
                 self.set_parameter_file(p)
-                self.set_template_path(
-                    self.get_s3_url(self.get_template_file()))
-                self.set_parameter_path(
-                    self.get_s3_url(self.get_parameter_file()))
+                self.set_template_path(self.s3_url_prefix + '/templates/' + self.get_template_file())
+                self.set_parameter_path(self.s3_url_prefix + '/ci/' + self.get_parameter_file())
 
                 # Check to make sure template filenames are correct
                 template_path = self.get_template_path()
@@ -1544,7 +1479,7 @@ class TaskCat(object):
 
                 # Detect template type
 
-                cfntemplate = self.get_s3contents(self.get_s3_url(self.get_template_file()))
+                cfntemplate = self.get_contents("./" + self.get_project() + '/templates/' + self.get_template_file())
 
                 if self.check_json(cfntemplate, quiet=True, strict=False):
                     self.set_template_type('json')
@@ -1983,11 +1918,6 @@ class TaskCat(object):
             action='store_true',
             help="Enables verbosity")
         parser.add_argument(
-            '-m',
-            '--multithread_upload',
-            action='store_true',
-            help="Enables multithreaded upload to S3")
-        parser.add_argument(
             '-t',
             '--tag',
             action=AppendTag,
@@ -2010,6 +1940,11 @@ class TaskCat(object):
             '--version',
             action='store_true',
             help="Prints Version")
+        parser.add_argument(
+            '-u',
+            '--upload-only',
+            action='store_true',
+            help="Sync local files with s3 and exit")
 
         args = parser.parse_args()
 
@@ -2022,13 +1957,13 @@ class TaskCat(object):
             print(get_installed_version())
             exit0()
 
+        if args.upload_only:
+            self.upload_only = True
+
         if not args.config_yml:
             parser.error("-c (--config_yml) not passed (Config File Required!)")
             print(parser.print_help())
             raise TaskCatException("-c (--config_yml) not passed (Config File Required!)")
-
-        if args.multithread_upload:
-            self.multithread_upload = True
 
         try:
             self.tags = args.tags


### PR DESCRIPTION
## Overview

Currently taskcat simply pushes all local files to a bucket on each run, regardless of whether files have changed, it also leaves files in s3 that are no longer in the local project.

This changes behavior to upload only changed files, and delete files not present locally. Speeds up upload when only small changes have been made.

adds `--upload-only` switch that syncs s3 and then exits.

## Testing/Steps taken to ensure quality

launched a quickstart

### Notes

Uses undocumented behavior for checksums of multipart uploads, see https://github.com/aws/aws-cli/issues/2585#issue-226758933

No longer fetching template and parameters from s3, but fetching locally instead. 

enforces template path to `templates/` and parameters to `ci/`, not sure if there are any existing quick starts that don't follow this pattern.

No unit tests yet 😞

Could use a global override option for bucket name, this way a user can use a single bucket for all their taskcat work.

## Testing Instructions

tested against the openshift quick start.
