### PR TITLE
allow launching taskcat from within the project folder

### DIFF
--- a/bin/taskcat
+++ b/bin/taskcat
@@ -48,6 +48,15 @@ def main():
                 taskcat_cfg = yaml.safe_load(cfg.read())
             cfg.close()
 
+            # If taskcat is being executed from the project root folder, cd out and update config path
+            try:
+                if os.path.basename(os.path.abspath(os.path.curdir)) == taskcat_cfg['global']['qsname']:
+                    config_path = tcat_instance.get_config()[2:] if tcat_instance.get_config().startswith(
+                        "./") else tcat_instance.get_config()
+                    os.chdir(os.path.abspath("../"))
+                    tcat_instance.set_config("%s/%s" % (taskcat_cfg['global']['qsname'], config_path))
+            except Exception as e:
+                print(taskcat.PrintMsg.ERROR + str(e))
             try:
                 project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
                 if project_path:


### PR DESCRIPTION
## Overview

Currently taskcat must be launched from outside the project folder. This is mildly annoying because I'm commonly running git commands and what-not from inside the project folder, and then each time I want to run tcat I need to cd out, run and cd back in.

## Testing/Steps taken to ensure quality

tested launching tcat from both within and outside of the project folder.

## Testing Instructions

```
cd quickstart-project-name
taskcat -c ./ci/config.yaml
```
