### PR TITLE
automatically generate lambda packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,3 +278,14 @@ Parameters defined in either file will supersede parameters within the normal pa
 
 Note: Keys defined in the Project override with supersede the same keys defined in the global override.
 [More info here](https://aws-quickstart.github.io/input-files.html#parm-override)
+
+### Packaging lambda functions
+Taskcat can automatically zip lambda function source found in `functions/source/*` folders. folders are zipped up and 
+placed in `functions/packages/FunctionName/lambda.zip`. To enable this functionality you will need to enable it in your 
+`taskcat.yaml` file by adding `package-lambda: true` to the `global` section:
+
+```yaml
+global:
+  package-lambda: true
+  ...
+```

--- a/README.md
+++ b/README.md
@@ -289,3 +289,6 @@ global:
   package-lambda: true
   ...
 ```
+
+Additionally, taskcat can be set to package zips and then exit without taking any other actions. This can be done by 
+setting the `-b` or `--lambda-build-only` flag.

--- a/bin/taskcat
+++ b/bin/taskcat
@@ -15,7 +15,9 @@ import yaml
 import sys
 import os
 import traceback
+from taskcat.common_utils import exit0
 from taskcat.common_utils import exit1
+from taskcat.lambda_build import LambdaBuild
 
 
 if sys.version_info[0] < 3:
@@ -57,11 +59,21 @@ def main():
                     tcat_instance.set_config("%s/%s" % (taskcat_cfg['global']['qsname'], config_path))
             except Exception as e:
                 print(taskcat.PrintMsg.ERROR + str(e))
+            project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
+            project_name = '/'.join(tcat_instance.get_config().split('/')[-3:-2])
+            lambda_path = os.path.abspath(project_path) + "/" + project_name + "/functions/source"
             try:
-                project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
+                if os.path.isdir(lambda_path):
+                    LambdaBuild(lambda_path)
+            except Exception as e:
+                print("ERROR: Zipping lambda source failed: %s" % e)
+            if tcat_instance.lambda_build_only:
+                exit0("Lambda source zipped successfully")
+            print(os.path.abspath(os.curdir))
+            try:
                 if project_path:
                     os.chdir(os.path.abspath(project_path))
-                    tcat_instance.lint(args.lint, path='/'.join(tcat_instance.get_config().split('/')[-3:-2]))
+                tcat_instance.lint(args.lint, path=project_name)
             except taskcat.exceptions.TaskCatException as e:
                 print(taskcat.PrintMsg.ERROR + str(e))
                 exit1(str(e))

--- a/bin/taskcat
+++ b/bin/taskcat
@@ -62,14 +62,18 @@ def main():
             project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
             project_name = '/'.join(tcat_instance.get_config().split('/')[-3:-2])
             lambda_path = os.path.abspath(project_path) + "/" + project_name + "/functions/source"
-            try:
-                if os.path.isdir(lambda_path):
-                    LambdaBuild(lambda_path)
-            except Exception as e:
-                print("ERROR: Zipping lambda source failed: %s" % e)
-            if tcat_instance.lambda_build_only:
-                exit0("Lambda source zipped successfully")
-            print(os.path.abspath(os.curdir))
+            if "package-lambda" in taskcat_cfg['global']:
+                taskcat_cfg['global']["package-lambda"] = False
+            if tcat_instance.lambda_build_only and not taskcat_cfg['global']["package-lambda"]:
+                exit1("Lambda build not enabled for project. Add package-lambda: true to config.yaml global section")
+            elif taskcat_cfg['global']["package-lambda"]:
+                try:
+                    if os.path.isdir(lambda_path):
+                        LambdaBuild(lambda_path)
+                except Exception as e:
+                    print("ERROR: Zipping lambda source failed: %s" % e)
+                if tcat_instance.lambda_build_only:
+                    exit0("Lambda source zipped successfully")
             try:
                 if project_path:
                     os.chdir(os.path.abspath(project_path))

--- a/bin/taskcat
+++ b/bin/taskcat
@@ -61,13 +61,13 @@ def main():
                 print(taskcat.PrintMsg.ERROR + str(e))
             project_path = '/'.join(tcat_instance.get_config().split('/')[0:-3])
             project_name = '/'.join(tcat_instance.get_config().split('/')[-3:-2])
-            lambda_path = os.path.abspath(project_path) + "/" + project_name + "/functions/source"
-            if "package-lambda" in taskcat_cfg['global']:
+            if "package-lambda" not in taskcat_cfg['global']:
                 taskcat_cfg['global']["package-lambda"] = False
             if tcat_instance.lambda_build_only and not taskcat_cfg['global']["package-lambda"]:
                 exit1("Lambda build not enabled for project. Add package-lambda: true to config.yaml global section")
             elif taskcat_cfg['global']["package-lambda"]:
                 try:
+                    lambda_path = os.path.abspath(project_path) + "/" + project_name + "/functions/source"
                     if os.path.isdir(lambda_path):
                         LambdaBuild(lambda_path)
                 except Exception as e:

--- a/taskcat/__init__.py
+++ b/taskcat/__init__.py
@@ -8,3 +8,4 @@ from taskcat.utils import *
 from taskcat.client_factory import ClientFactory
 from taskcat.exceptions import TaskCatException
 from taskcat.s3_sync import S3Sync
+from taskcat.lambda_build import LambdaBuild

--- a/taskcat/common_utils.py
+++ b/taskcat/common_utils.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import os
 from taskcat.colored_console import PrintMsg
 
 
@@ -48,3 +49,10 @@ def exit0(msg=''):
     if msg:
         print(PrintMsg.INFO + msg)
     sys.exit(0)
+
+
+def make_dir(path, ignore_exists=True):
+    path = os.path.abspath(path)
+    if ignore_exists and os.path.isdir(path):
+        return
+    os.makedirs(path)

--- a/taskcat/common_utils.py
+++ b/taskcat/common_utils.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from taskcat.colored_console import PrintMsg
 
 
 class CommonTools:
@@ -38,8 +39,12 @@ class CommonTools:
 
 
 def exit1(msg=''):
+    if msg:
+        print(PrintMsg.ERROR + msg)
     sys.exit(1)
 
 
 def exit0(msg=''):
+    if msg:
+        print(PrintMsg.INFO + msg)
     sys.exit(0)

--- a/taskcat/lambda_build.py
+++ b/taskcat/lambda_build.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 import os
 from shutil import make_archive
 from taskcat.colored_console import PrintMsg
-
+from taskcat.common_utils import make_dir
 
 class LambdaBuild(object):
     """Zips contents of lambda source files.
@@ -40,15 +40,8 @@ class LambdaBuild(object):
         try:
             print(PrintMsg.INFO + "Zipping lambda function %s" % name)
             output_path = "%s/%s" % (self.output_path, name)
-            self._make_dir(output_path)
+            make_dir(output_path)
             os.chdir(name)
             make_archive(output_path + "/" + self.zip_file_name, "zip", "./")
         finally:
             os.chdir(self.source_path)
-
-    @staticmethod
-    def _make_dir(path, ignore_exists=True):
-        path = os.path.abspath(path)
-        if ignore_exists and os.path.isdir(path):
-            return
-        os.makedirs(path)

--- a/taskcat/lambda_build.py
+++ b/taskcat/lambda_build.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# authors:
+# Tony Vattathil <tonynv@amazon.com>, <avattathil@gmail.com>
+# Santiago Cardenas <sancard@amazon.com>, <santiago[dot]cardenas[at]outlook[dot]com>
+# Shivansh Singh <sshvans@amazon.com>,
+# Jay McConnell <jmmccon@amazon.com>,
+# Andrew Glenn <andglenn@amazon.com>
+from __future__ import print_function
+
+
+import os
+from shutil import make_archive
+from taskcat.colored_console import PrintMsg
+
+
+class LambdaBuild(object):
+    """Zips contents of lambda source files.
+
+    """
+
+    zip_file_name = "lambda"
+
+    def __init__(self, source_path, output_path="../packages"):
+
+        cur_dir = os.path.abspath(os.curdir)
+        try:
+            self.source_path = os.path.abspath(source_path)
+            os.chdir(self.source_path)
+            self.output_path = os.path.abspath(output_path)
+
+            dirs = [ i for i in os.listdir("./") if os.path.isdir(i) ]
+            for dir in dirs:
+                self._make_zip(dir)
+        finally:
+            os.chdir(cur_dir)
+        return
+
+    def _make_zip(self, name):
+        try:
+            print(PrintMsg.INFO + "Zipping lambda function %s" % name)
+            output_path = "%s/%s" % (self.output_path, name)
+            self._make_dir(output_path)
+            os.chdir(name)
+            make_archive(output_path + "/" + self.zip_file_name, "zip", "./")
+        finally:
+            os.chdir(self.source_path)
+
+    @staticmethod
+    def _make_dir(path, ignore_exists=True):
+        path = os.path.abspath(path)
+        if ignore_exists and os.path.isdir(path):
+            return
+        os.makedirs(path)

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -190,6 +190,7 @@ class TaskCat(object):
         self.s3_url_prefix = ""
         self.upload_only = False
         self._max_bucket_name_length = 63
+        self.lambda_build_only = False
 
         # SETTERS ANPrintMsg.DEBUG GETTERS
     # ===================
@@ -1958,6 +1959,11 @@ class TaskCat(object):
             '--upload-only',
             action='store_true',
             help="Sync local files with s3 and exit")
+        parser.add_argument(
+            '-b',
+            '--lambda-build-only',
+            action='store_true',
+            help="create lambda zips and exit")
 
         args = parser.parse_args()
 
@@ -1972,6 +1978,9 @@ class TaskCat(object):
 
         if args.upload_only:
             self.upload_only = True
+
+        if args.lambda_build_only:
+            self.lambda_build_only = True
 
         if not args.config_yml:
             parser.error("-c (--config_yml) not passed (Config File Required!)")


### PR DESCRIPTION
## Overview

Currently, projects that include lambda functions must commit zipped lambda packages to `functions/packages` and maintainers must manually ensure the contents of the zips are up to date with the `functions/source` files. 

This PR adds functionality to check for the presence of a `functions/source` folder and create zips before uploading to s3. 

## Testing/Steps taken to ensure quality

Tested with several Quick Start's containing lambda source code

### Notes

with this in place, zips no longer need to be committed, and `functions/packages` can be safely added to `.gitignore`

added the `--lambda-build-only` flag to create zips and exit

## Testing Instructions

* Pull a Quick Start containing lambda zips
* delete the packages folder
* execute taskcat, zips should get created, uploaded to s3 and taskcat run complete successfully
