### PR TITLE
Updates to bucket mismatch wording; adding override validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![TaskCat logo](https://raw.githubusercontent.com/aws-quickstart/taskcat/master/assets/docs/images/logo.png)
 > This program requires python3
 
-Please Report bugs here [Issues](https://github.com/aws-quickstart/taskcat/issues)
+[Please Report bugs here ](https://github.com/aws-quickstart/taskcat/issues)
 
 For helpful information see [Frequently Asked Questions](FAQ.md)
 

--- a/examples/sample-taskcat-project/ci/debug-input.json
+++ b/examples/sample-taskcat-project/ci/debug-input.json
@@ -38,5 +38,9 @@
     {
         "ParameterKey": "PasswordB",
         "ParameterValue": "$[taskcat_genpass_32S]"
+    },
+    {
+        "ParameterKey":"OverrideTest",
+        "ParameterValue":"override"
     }
 ]

--- a/examples/sample-taskcat-project/ci/debug-input.json
+++ b/examples/sample-taskcat-project/ci/debug-input.json
@@ -40,7 +40,11 @@
         "ParameterValue": "$[taskcat_genpass_32S]"
     },
     {
-        "ParameterKey":"OverrideTest",
+        "ParameterKey":"LocalOverrideTest",
+        "ParameterValue":"override"
+    }
+    {
+        "ParameterKey":"GlobalOverrideTest",
         "ParameterValue":"override"
     }
 ]

--- a/examples/sample-taskcat-project/ci/taskcat.yml
+++ b/examples/sample-taskcat-project/ci/taskcat.yml
@@ -2,7 +2,6 @@
 global:
   owner: owner@company.com
   qsname: sample-taskcat-project
-  s3bucket: taskcat-sample-taskcat-project-a1c14bc9
   regions:
     - ap-northeast-1
     - ap-northeast-2

--- a/examples/sample-taskcat-project/ci/taskcat_project_override.json
+++ b/examples/sample-taskcat-project/ci/taskcat_project_override.json
@@ -1,0 +1,6 @@
+[
+    {
+        "ParameterKey":"OverrideTest",
+        "ParameterValue":"foobar"
+    }
+]

--- a/examples/sample-taskcat-project/ci/taskcat_project_override.json
+++ b/examples/sample-taskcat-project/ci/taskcat_project_override.json
@@ -1,6 +1,6 @@
 [
     {
-        "ParameterKey":"OverrideTest",
+        "ParameterKey":"GlobalOverrideTest",
         "ParameterValue":"foobar"
     }
 ]

--- a/examples/sample-taskcat-project/templates/debug-yaml.template
+++ b/examples/sample-taskcat-project/templates/debug-yaml.template
@@ -28,8 +28,12 @@ Parameters:
   AvailabilityZones:
     Description: 'List of 3 Availability Zones '
     Type: List<AWS::EC2::AvailabilityZone::Name>
-  OverrideTest:
-    Description: Test of the parameter override functionality
+  LocalOverrideTest:
+    Description: Test of the local parameter override functionality
+    Type: String
+    Default: override
+  GlobalOverrideTest:
+    Description: Test of the global parameter override functionality
     Type: String
     Default: override
 Rules:
@@ -37,9 +41,14 @@ Rules:
     Assertions:
       - Assert: !Not
           - !Equals
-            - !Ref 'OverrideTest'
+            - !Ref 'LocalOverrideTest'
             - override
-        AssertDescription: Param key 'OverrideTest' cannot equal 'override'
+        AssertDescription: Param key 'LocalOverrideTest' cannot equal 'override'
+      - Assert: !Not
+          - !Equals
+            - !Ref 'GlobalOverrideTest'
+            - override
+        AssertDescription: Param key 'GlobalOverrideTest' cannot equal 'override'
 Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role

--- a/examples/sample-taskcat-project/templates/debug-yaml.template
+++ b/examples/sample-taskcat-project/templates/debug-yaml.template
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Description: Lambda  Cluster Id generator
 Parameters:
   StackName:
@@ -27,53 +27,65 @@ Parameters:
     Type: Number
   AvailabilityZones:
     Description: 'List of 3 Availability Zones '
-    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+  OverrideTest:
+    Description: Test of the parameter override functionality
+    Type: String
+    Default: override
+Rules:
+  VerifyOverrides:
+    Assertions:
+      - Assert: !Not
+          - !Equals
+            - !Ref 'OverrideTest'
+            - override
+        AssertDescription: Param key 'OverrideTest' cannot equal 'override'
 Resources:
   LambdaExecutionRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
       Path: /
       Policies:
         - PolicyName: lambda_policy
           PolicyDocument:
-            Version: 2012-10-17
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
-                  - 'logs:CreateLogGroup'
-                  - 'logs:CreateLogStream'
-                  - 'logs:PutLogEvents'
-                Resource: 'arn:aws:logs:*:*:*'
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
               - Effect: Allow
                 Action:
-                  - 'cloudformation:DescribeStacks'
+                  - cloudformation:DescribeStacks
                 Resource: '*'
   GenID:
-    Type: 'AWS::Lambda::Function'
+    Type: AWS::Lambda::Function
     Properties:
       Code:
-        ZipFile: !Join 
-          - |+
-
+        ZipFile: !Join
+          - "\n"
           - - import random
             - import json
             - import cfnresponse
-            - 'from cfnresponse import send, SUCCESS'
+            - from cfnresponse import send, SUCCESS
             - 'def handler(event, context):'
             - '   if event[''RequestType''] == ''Delete'':'
             - '       send(event, context, ''SUCCESS'', {})'
             - '       return'
             - '   if event[''RequestType''] == ''Create'':'
-            - '       token= "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))'
+            - '       token= "%0x.%0x" % (random.SystemRandom().getrandbits(3*8),
+              random.SystemRandom().getrandbits(8*8))'
             - '       responseData = {}'
             - '       responseData[''Data''] = token'
             - '       send(event, context, ''SUCCESS'', responseData)'
@@ -81,25 +93,21 @@ Resources:
       Handler: index.handler
       Runtime: python2.7
       Timeout: '5'
-      Role: !GetAtt 
-        - LambdaExecutionRole
-        - Arn
+      Role: !GetAtt 'LambdaExecutionRole.Arn'
   GetID:
-    Type: 'Custom::GenerateID'
+    Type: Custom::GenerateID
     Version: '1.0'
     Properties:
-      ServiceToken: !GetAtt 
-        - GenID
-        - Arn
-      ResponseURL: !Join 
+      ServiceToken: !GetAtt 'GenID.Arn'
+      ResponseURL: !Join
         - ''
-        - - 'http://ResponseURL'
+        - - http://ResponseURL
           - !Ref 'AWS::StackId'
           - RequestId
       StackId: !Ref 'AWS::StackId'
       ResourceProperties:
         RequestType: Create
-        RequestId: !Join 
+        RequestId: !Join
           - ''
           - - !Ref 'AWS::StackId'
             - RequestId
@@ -108,7 +116,4 @@ Resources:
       - GenID
 Outputs:
   ClusterID:
-    Value: !GetAtt 
-      - GetID
-      - Data
-
+    Value: !GetAtt 'GetID.Data'

--- a/examples/sample-taskcat-project/templates/debug.template
+++ b/examples/sample-taskcat-project/templates/debug.template
@@ -37,7 +37,26 @@
         "AvailabilityZones": {
             "Description": "List of 3 Availability Zones ",
             "Type": "List<AWS::EC2::AvailabilityZone::Name>"
+        },
+        "OverrideTest":{
+            "Description": "Test of the parameter override functionality",
+            "Type":"String",
+            "Default":"override"
+        },
+        "QSS3BucketName":{
+            "Default":"quickstart-foobar-bucket",
+            "Type":"String"
         }
+    },
+    "Rules":{
+      "VerifyOverrides":{
+        "Assertions":[
+          {
+            "Assert":{ "Fn::Not":[{ "Fn::Equals":[{"Ref":"OverrideTest"},"override"]}]},
+            "AssertDescription":"Param key 'OverrideTest' cannot equal 'override'"
+          }
+        ]
+      }
     },
     "Resources": {
         "LambdaExecutionRole": {

--- a/examples/sample-taskcat-project/templates/debug.template
+++ b/examples/sample-taskcat-project/templates/debug.template
@@ -38,25 +38,52 @@
             "Description": "List of 3 Availability Zones ",
             "Type": "List<AWS::EC2::AvailabilityZone::Name>"
         },
-        "OverrideTest":{
-            "Description": "Test of the parameter override functionality",
-            "Type":"String",
-            "Default":"override"
+        "LocalOverrideTest": {
+            "Description": "Test of the local parameter override functionality",
+            "Type": "String",
+            "Default": "override"
         },
-        "QSS3BucketName":{
-            "Default":"quickstart-foobar-bucket",
-            "Type":"String"
+        "GlobalOverrideTest": {
+            "Description": "Test of the global parameter override functionality",
+            "Type": "String",
+            "Default": "override"
         }
     },
-    "Rules":{
-      "VerifyOverrides":{
-        "Assertions":[
-          {
-            "Assert":{ "Fn::Not":[{ "Fn::Equals":[{"Ref":"OverrideTest"},"override"]}]},
-            "AssertDescription":"Param key 'OverrideTest' cannot equal 'override'"
-          }
-        ]
-      }
+    "Rules": {
+        "VerifyOverrides": {
+            "Assertions": [
+                {
+                    "Assert": {
+                        "Fn::Not": [
+                            {
+                                "Fn::Equals": [
+                                    {
+                                        "Ref": "LocalOverrideTest"
+                                    },
+                                    "override"
+                                ]
+                            }
+                        ]
+                    },
+                    "AssertDescription": "Param key 'LocalOverrideTest' cannot equal 'override'"
+                },
+                {
+                    "Assert": {
+                        "Fn::Not": [
+                            {
+                                "Fn::Equals": [
+                                    {
+                                        "Ref": "GlobalOverrideTest"
+                                    },
+                                    "override"
+                                ]
+                            }
+                        ]
+                    },
+                    "AssertDescription": "Param key 'GlobalOverrideTest' cannot equal 'override'"
+                }
+            ]
+        }
     },
     "Resources": {
         "LambdaExecutionRole": {
@@ -64,36 +91,47 @@
             "Properties": {
                 "AssumeRolePolicyDocument": {
                     "Version": "2012-10-17",
-                    "Statement": [{
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Service": ["lambda.amazonaws.com"]
-                        },
-                        "Action": ["sts:AssumeRole"]
-                    }]
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
                 },
                 "Path": "/",
-                "Policies": [{
-                    "PolicyName": "lambda_policy",
-                    "PolicyDocument": {
-                        "Version": "2012-10-17",
-                        "Statement": [{
-                            "Effect": "Allow",
-                            "Action": [
-                                "logs:CreateLogGroup",
-                                "logs:CreateLogStream",
-                                "logs:PutLogEvents"
-                            ],
-                            "Resource": "arn:aws:logs:*:*:*"
-                        }, {
-                        "Effect": "Allow",
-                        "Action": [
-                            "cloudformation:DescribeStacks"
-                        ],
-                        "Resource": "*"
-                        }]
+                "Policies": [
+                    {
+                        "PolicyName": "lambda_policy",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": "arn:aws:logs:*:*:*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "cloudformation:DescribeStacks"
+                                    ],
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
                     }
-                }]
+                ]
             }
         },
         "GenID": {
@@ -101,29 +139,35 @@
             "Properties": {
                 "Code": {
                     "ZipFile": {
-                        "Fn::Join": ["\n", [
-                            "import random",
-                            "import json",
-                            "import cfnresponse",
-                            "from cfnresponse import send, SUCCESS",
-                            "def handler(event, context):",
-                            "   if event['RequestType'] == 'Delete':",
-                            "       send(event, context, 'SUCCESS', {})",
-                            "       return",
-                            "   if event['RequestType'] == 'Create':",
-                            "       token= \"%0x.%0x\" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))",
-                            "       responseData = {}",
-                            "       responseData['Data'] = token",
-                            "       send(event, context, 'SUCCESS', responseData)",
-                            "       return token"
-                        ]]
+                        "Fn::Join": [
+                            "\n",
+                            [
+                                "import random",
+                                "import json",
+                                "import cfnresponse",
+                                "from cfnresponse import send, SUCCESS",
+                                "def handler(event, context):",
+                                "   if event['RequestType'] == 'Delete':",
+                                "       send(event, context, 'SUCCESS', {})",
+                                "       return",
+                                "   if event['RequestType'] == 'Create':",
+                                "       token= \"%0x.%0x\" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))",
+                                "       responseData = {}",
+                                "       responseData['Data'] = token",
+                                "       send(event, context, 'SUCCESS', responseData)",
+                                "       return token"
+                            ]
+                        ]
                     }
                 },
                 "Handler": "index.handler",
                 "Runtime": "python2.7",
                 "Timeout": "5",
                 "Role": {
-                    "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]
+                    "Fn::GetAtt": [
+                        "LambdaExecutionRole",
+                        "Arn"
+                    ]
                 }
             }
         },
@@ -132,23 +176,54 @@
             "Version": "1.0",
             "Properties": {
                 "ServiceToken": {
-                    "Fn::GetAtt": ["GenID", "Arn"]
+                    "Fn::GetAtt": [
+                        "GenID",
+                        "Arn"
+                    ]
                 },
-                "ResponseURL":  {"Fn::Join": ["", [ "http://ResponseURL",{ "Ref": "AWS::StackId" },"RequestId" ]]},
-                "StackId": { "Ref": "AWS::StackId" },
+                "ResponseURL": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "http://ResponseURL",
+                            {
+                                "Ref": "AWS::StackId"
+                            },
+                            "RequestId"
+                        ]
+                    ]
+                },
+                "StackId": {
+                    "Ref": "AWS::StackId"
+                },
                 "ResourceProperties": {
                     "RequestType": "Create",
-                    "RequestId":  {"Fn::Join": ["", [{ "Ref": "AWS::StackId" },"RequestId" ]]},
-                    "LogicalResourceId":  "GenIDLogicalResourceId"
+                    "RequestId": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                {
+                                    "Ref": "AWS::StackId"
+                                },
+                                "RequestId"
+                            ]
+                        ]
+                    },
+                    "LogicalResourceId": "GenIDLogicalResourceId"
                 }
             },
-            "DependsOn": ["GenID"]
+            "DependsOn": [
+                "GenID"
+            ]
         }
     },
     "Outputs": {
         "ClusterID": {
             "Value": {
-                "Fn::GetAtt": ["GetID", "Data"]
+                "Fn::GetAtt": [
+                    "GetID",
+                    "Data"
+                ]
             }
         }
     }

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -335,9 +335,9 @@ class TaskCat(object):
             if _kn in param_index:
                 _knidx = param_index[_kn]
                 param_bucket_name = original_keys[_knidx]['ParameterValue']
-                if param_bucket_name != bucket_name:
+                if param_bucket_name != bucket_name and param_bucket_name != '$[taskcat_autobucket]':
                     print(
-                        PrintMsg.INFO + "Data inconsistency between S3 Bucket Name [{}] and QSS3BucketName Parameter Value: [{}]".format(
+                        PrintMsg.INFO + "Inconsistency detected between S3 Bucket Name provided in the TaskCat Config [{}] and QSS3BucketName Parameter Value within the template: [{}]".format(
                             bucket_name, param_bucket_name))
                     print(PrintMsg.INFO + "Setting the value of QSS3BucketName to [{}]".format(bucket_name))
                     original_keys[_knidx]['ParameterValue'] = bucket_name


### PR DESCRIPTION
## Overview

This PR Updates wording around a mismatch between the QSS3BucketName parameter passed to templates (either via a parameter value, or default value) and what taskcat expects as a bucket name. This PR also removes this message from occuring if the $[taskcat_autobucket] placeholder is passed. 

Additionally - this PR adds checks to the sample taskcat templates to verify overrides are working as intended.