### PR TITLE
improve error handling on s3 upload failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Misc #
 .idea/
 .project
+.eggs/
+*.egg-info/
+venv/
 
 # Doc Site
 site/


### PR DESCRIPTION
## Overview

Minor improvement to stop retries for `AccessDenied` errors, which are permanent. Also moves the print to before the actual upload so we can see what is busy being uploaded

## Testing/Steps taken to ensure quality

test against bucket where I don't have PutObject access.

## Testing Instructions

create a user without `s3:PutObject` or `s3:PutObjectACL` permission. run taskcat using that user. Uploads should not be retried, taskcat should exit(1), and output look something like:
```
[S3: -> ] s3://taskcat-tag-quickstart-redhat-openshift-0167d07c/quickstart-suse-cloud-application-platform/submodules/quickstart-aws-eks/functions/source/KubeManifest/bin/aws-iam-authenticator
[ERROR  ] :S3 upload error: Failed to upload /Users/jmmccon/quickstart-suse-cloud-application-platform/submodules/quickstart-aws-eks/functions/packages/Helm/lambda.zip to taskcat-tag-quickstart-redhat-openshift-0167d07c/quickstart-suse-cloud-application-platform/submodules/quickstart-aws-eks/functions/packages/Helm/lambda.zip: An error occurred (AccessDenied) when calling the CreateMultipartUpload operation: Access Denied
[ERROR  ] :Failed to upload object to S3
```
