### PR TITLE
lint improvements

### DIFF
--- a/bin/taskcat
+++ b/bin/taskcat
@@ -18,6 +18,7 @@ import traceback
 from taskcat.common_utils import exit0
 from taskcat.common_utils import exit1
 from taskcat.lambda_build import LambdaBuild
+from taskcat.cfn_lint import Lint
 
 
 if sys.version_info[0] < 3:
@@ -77,16 +78,15 @@ def main():
             try:
                 if project_path:
                     os.chdir(os.path.abspath(project_path))
-                tcat_instance.lint(args.lint, path=project_name)
+                Lint(config=tcat_instance.get_config(), path=project_name).output_results()
             except taskcat.exceptions.TaskCatException as e:
                 print(taskcat.PrintMsg.ERROR + str(e))
                 exit1(str(e))
             except Exception as e:
                 print("ERROR: Linting failed: %s" % e)
-                if args.lint in ['error', 'strict']:
-                    raise
-                else:
-                    traceback.print_exc()
+                traceback.print_exc()
+            if args.lint:
+                exit0("Linting completed")
             tcat_instance.stage_in_s3(taskcat_cfg)
             tcat_instance.validate_template(taskcat_cfg, test_list)
             tcat_instance.validate_parameters(taskcat_cfg, test_list)
@@ -100,5 +100,6 @@ def main():
         exit1(str(e))
 
 # --End
+
 
 main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mock==2.0.0
 tabulate==0.8.2
 pyfiglet==0.7.5
-cfn_lint==0.7.4
+cfn_lint==0.9.0
 setuptools==40.4.3
 boto3==1.9.21
 botocore==1.12.21

--- a/taskcat/cfn_lint.py
+++ b/taskcat/cfn_lint.py
@@ -1,0 +1,129 @@
+import textwrap
+import cfnlint.core
+from yaml.scanner import ScannerError
+from taskcat.colored_console import PrintMsg
+import yaml
+import re
+
+
+class Lint(object):
+
+    _code_regex = re.compile("^([WER][0-9]*:)")
+
+    def __init__(self, config, path=""):
+        """
+        Lints templates using cfn_python_lint. Uses config file to define regions and templates to test. Recurses into
+        child templates, excluding submodules.
+
+        :param config: path to tascat ci config file
+        """
+        self._config = yaml.safe_load(open(config))
+        self._rules = cfnlint.core.get_rules([], [], [])
+        self._path = path
+        self.lints = self._lint()
+
+    def _get_template_path(self, test):
+        if self._path:
+            return '%s/templates/%s' % (self._path, self._config['tests'][test]['template_file'])
+        else:
+            return 'templates/%s' % (self._config['tests'][test]['template_file'])
+
+    def _get_test_regions(self, test):
+        if 'regions' in self._config['tests'][test].keys():
+            return self._config['tests'][test]['regions']
+        else:
+            return self._config['global']['regions']
+
+    @staticmethod
+    def _parse_template(template_path, quiet=False):
+        try:
+            return cfnlint.decode.cfn_yaml.load(template_path)
+        except ScannerError as e:
+            if not quiet:
+                print(PrintMsg.ERROR + 'Linter failed to load template %s "%s" line %s, column %s' % (
+                      template_path, e.problem, e.problem_mark.line, e.problem_mark.column))
+        except FileNotFoundError as e:
+            if not quiet:
+                print(PrintMsg.ERROR + 'Linter failed to load template %s "%s"' % (template_path, str(e)))
+
+    def _lint(self):
+        lints = {}
+        templates = {}
+
+        for test in self._config['tests'].keys():
+            lints[test] = {}
+            lints[test]['regions'] = self._get_test_regions(test)
+            template_file = self._get_template_path(test)
+            lints[test]['template_file'] = template_file
+            if template_file not in templates.keys():
+                templates[template_file] = self._get_child_templates(template_file, set(), parent_path=self._path)
+            lints[test]['results'] = {}
+            templates[template_file].add(template_file)
+            for t in templates[template_file]:
+                template = self._parse_template(t, quiet=True)
+                if template:
+                    lints[test]['results'][t] = cfnlint.core.run_checks(
+                        t, template, self._rules, lints[test]['regions']
+                    )
+        return lints
+
+    def output_results(self):
+        """
+        Prints lint results to terminal using taskcat console formatting
+
+        :return:
+        """
+        for test in self.lints.keys():
+            for t in self.lints[test]['results'].keys():
+                if len(self.lints[test]['results'][t]) == 0:
+                    print(PrintMsg.INFO + "Lint passed for test %s on template %s:" % (test, t))
+                else:
+                    print(PrintMsg.ERROR + "Lint detected issues for test %s on template %s:" % (test, t))
+                for r in self.lints[test]['results'][t]:
+                    print(self._format_message(r, test, t))
+
+    def _format_message(self, message, test, t):
+        message = message.__str__().lstrip('[')
+        sev = message[0]
+        code = Lint._code_regex.findall(message)[0][:-1]
+        path = message.split(" ")[-1]
+        line_no = ""
+        if len(path.split(":")) == 2:
+            line_no = path.split(":")[1]
+        prefix = "    line " + line_no + " [" + code + "] ["
+        indent = "\n" + " " * (2 + len(prefix))
+        message = indent.join(textwrap.wrap(" ".join(message.split(" ")[1:-2]), 141-(len(indent) + 11)))
+        message = prefix + message
+        if sev == 'E':
+            return PrintMsg.ERROR + message
+        elif sev == 'W':
+            if 'E' + message[1:] not in [r.__str__().lstrip('[') for r in self.lints[test]['results'][t]]:
+                return PrintMsg.INFO + message
+        else:
+            return PrintMsg.DEBUG + "linter produced unkown output: " + message
+
+    def _get_child_templates(self, filename, children, parent_path=''):
+        template = self._parse_template(filename)
+        if not template:
+            return children
+        for resource in template['Resources'].keys():
+            child_name = ''
+            if template['Resources'][resource]['Type'] == "AWS::CloudFormation::Stack":
+                template_url = template['Resources'][resource]['Properties']['TemplateURL']
+                if isinstance(template_url, dict):
+                    if 'Fn::Sub' in template_url.keys():
+                        if isinstance(template_url['Fn::Sub'], str):
+                            child_name = template_url['Fn::Sub'].split('}')[-1]
+                        else:
+                            child_name = template_url['Fn::Sub'][0].split('}')[-1]
+                    elif 'Fn::Join' in list(template_url.keys())[0]:
+                        child_name = template_url['Fn::Join'][1][-1]
+                elif isinstance(template_url, str):
+                    if 'submodules/' not in template_url:
+                        child_name = '/'.join(template_url.split('/')[-2:])
+            if child_name and not child_name.startswith('submodules/'):
+                if parent_path:
+                    child_name = "%s/%s" % (parent_path, child_name)
+                children.add(child_name)
+                children.union(self._get_child_templates(child_name, children, parent_path=parent_path))
+        return children

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -27,7 +27,6 @@ import os
 import random
 import re
 import sys
-import textwrap
 import time
 import uuid
 import boto3
@@ -35,6 +34,7 @@ import pyfiglet
 import yaml
 import logging
 import cfnlint.core
+import textwrap
 from argparse import RawTextHelpFormatter
 from botocore.vendored import requests
 
@@ -1605,96 +1605,6 @@ class TaskCat(object):
             return False
         return True
 
-    def lint(self, strict='warn', path=''):
-        """
-        Lints all templates (against each region to be tested) using cfn_python_lint
-
-        :param path:
-        :param strict: string, "error" outputs a log line for each warning and fails on errors, if set to "strict"
-        will exit on warnings and failures, if set to "warn" will only output warnings for errors
-        :return:
-        """
-        if strict not in ['error', 'strict', 'warn']:
-            raise TaskCatException("lint was set to an invalid value '%s', valid values are: 'error', 'strict', 'warn'" % strict)
-        lints = {}
-        templates = {}
-        config = yaml.safe_load(open(self.config))
-        rules = cfnlint.core.get_rules([], [])
-        for test in config['tests'].keys():
-            lints[test] = {}
-            if 'regions' in config['tests'][test].keys():
-                lints[test]['regions'] = config['tests'][test]['regions']
-            else:
-                lints[test]['regions'] = config['global']['regions']
-            if path:
-                template_file = '%s/templates/%s' % (path, config['tests'][test]['template_file'])
-            else:
-                template_file = 'templates/%s' % (config['tests'][test]['template_file'])
-            lints[test]['template_file'] = template_file
-            if template_file not in templates.keys():
-                templates[template_file] = self.get_child_templates(template_file, parent_path=path)
-            lints[test]['results'] = {}
-            templates[template_file].add(template_file)
-            for t in templates[template_file]:
-                template = cfnlint.decode.cfn_yaml.load(t)
-                lints[test]['results'][t] = cfnlint.core.run_checks(
-                    t,
-                    template,
-                    rules,
-                    lints[test]['regions'])
-        test_status = {"W": False, "E": False}
-        for test in lints.keys():
-            for t in lints[test]['results'].keys():
-                print(PrintMsg.INFO + "Lint results for test %s on template %s:" % (test, t))
-                for r in lints[test]['results'][t]:
-                    message = r.__str__().lstrip('[')
-                    sev = message[0]
-                    if sev == 'E':
-                        print(PrintMsg.ERROR + "    " + message)
-                        test_status[sev] = True
-                    elif sev == 'W':
-                        if 'E' + message[1:] not in [r.__str__().lstrip('[') for r in lints[test]['results'][t]]:
-                            print(PrintMsg.INFO + "    " + message)
-                            test_status[sev] = True
-                    else:
-                        print(PrintMsg.DEBUG + "linter produced unkown output: " + message)
-        if strict in ['error', 'strict'] and test_status['E']:
-            raise TaskCatException("Exiting due to lint errors")
-        elif strict == 'strict' and test_status['W']:
-            raise TaskCatException("Exiting due to lint warnings")
-
-    def get_child_templates(self, filename, parent_path=''):
-        """
-        recursively find nested templates given a template path
-
-        :param parent_path:
-        :param filename: string, path to template
-        :return: set of nested template paths
-        """
-        children = set()
-        template = cfnlint.decode.cfn_yaml.load(filename)
-        for resource in template['Resources'].keys():
-            child_name = ''
-            if template['Resources'][resource]['Type'] == "AWS::CloudFormation::Stack":
-                template_url = template['Resources'][resource]['Properties']['TemplateURL']
-                if type(template_url) == dict:
-                    if 'Fn::Sub' in template_url.keys():
-                        if type(template_url['Fn::Sub']) == str:
-                            child_name = template_url['Fn::Sub'].split('}')[-1]
-                        else:
-                            child_name = template_url['Fn::Sub'][0].split('}')[-1]
-                    elif 'Fn::Join' in template_url.keys()[0]:
-                        child_name = template_url['Fn::Join'][1][-1]
-                elif type(template_url) == str:
-                    if 'submodules/' not in template_url:
-                        child_name = '/'.join(template_url.split('/')[-2:])
-            if child_name and not child_name.startswith('submodules/'):
-                if parent_path:
-                    child_name = "%s/%s" % (parent_path, child_name)
-                children.add(child_name)
-                children.union(self.get_child_templates(child_name, parent_path=parent_path))
-        return children
-
     # Set AWS Credentials
     # Set AWS Credentials
     def aws_api_init(self, args):
@@ -1947,10 +1857,8 @@ class TaskCat(object):
         parser.add_argument(
             '-l',
             '--lint',
-            type=str,
-            default="warn",
-            help="set linting 'strict' - will fail on errors and warnings, 'error' will fail on errors or 'warn' will "
-                 "log errors to the console, but not fail")
+            action='store_true',
+            help="lint the templates and exit")
         parser.add_argument(
             '-V',
             '--version',


### PR DESCRIPTION
## Overview

* major refactor
* change lint flag to lint and exit
* various bug fixes
* improve output formatting

## Testing/Steps taken to ensure quality

Tested against various quick starts

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

run against quick start with `--lint` to lint and exit, output should look something like:
```
> taskcat -c ./ci/config.yml --lint
...
[ERROR  ] :Linter failed to load template quickstart-redhat-openshift/templates/openshift.templatenon-exist "[Errno 2] No such file or directory: 'quickstart-redhat-openshift/templates/openshift.templatenon-exist'"
[ERROR  ] :Lint detected issues for test openshift on template quickstart-redhat-openshift/templates/openshift-master.template:
[INFO   ] :    line 226 [W2001] [Check if Parameters are Used] (Parameter ContainerAccessCIDR not used.)
[INFO   ] :    line 292 [W2001] [Check if Parameters are Used] (Parameter EtcdInstanceType not used.)
[INFO   ] :    line 310 [W2001] [Check if Parameters are Used] (Parameter NodesInstanceType not used.)
[INFO   ] :    line 336 [W2001] [Check if Parameters are Used] (Parameter NumberOfEtcd not used.)
[INFO   ] :    line 344 [W2001] [Check if Parameters are Used] (Parameter NumberOfNodes not used.)
[INFO   ] :Linting completed
```
