### PR TITLE
only test against regions supported by cfn-python-lint

### DIFF
--- a/taskcat/cfn_lint.py
+++ b/taskcat/cfn_lint.py
@@ -30,9 +30,18 @@ class Lint(object):
 
     def _get_test_regions(self, test):
         if 'regions' in self._config['tests'][test].keys():
-            return self._config['tests'][test]['regions']
+            return self._filter_unsupported_regions(self._config['tests'][test]['regions'])
         else:
-            return self._config['global']['regions']
+            return self._filter_unsupported_regions(self._config['global']['regions'])
+
+    def _filter_unsupported_regions(self, regions):
+        lint_regions = set(cfnlint.core.REGIONS)
+        if set(regions).issubset(lint_regions):
+            return regions
+        supported = set(regions).intersection(lint_regions)
+        unsupported = set(regions).difference(lint_regions)
+        print(PrintMsg.ERROR + "The following regions are not supported by cfn-python-lint and will not be linted %s" % unsupported)
+        return list(supported)
 
     @staticmethod
     def _parse_template(template_path, quiet=False):


### PR DESCRIPTION
## Overview

Currently cfn-python-lint exits, instead of raising an exception under some conditions. In these cases exception handling alone doesn't do the job. This PR handles the case where regions defined in tests are not supported by cfn-lint

## Testing/Steps taken to ensure quality

executed against various quickstarts.

### Notes

Will add a catchall for cfn-lint exiting unexpectedly in a followup pr

## Testing Instructions

test against a quickstart that includes an unsupported region like `eu-west-3`. will provide an error log, but continue to test against all supported regions:

```
[taskcat] |Queing test => quickstart-fortigate-test-ap-southeast-2
[ERROR  ] :The following regions are not supported by cfn-python-lint and will not be linted {'eu-west-3'}
[ERROR  ] :Lint detected issues for test quickstart-fortigate-test on template quickstart-fortinet-fortigate/templates/create-fortigate.template:
[INFO   ] :    line 39 [W2506] [Check if ImageId Parameters have the correct type] (Parameter FortiGateImageId should be of type
                       [AWS::EC2::Image::Id, AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>])
```

Previous behavior was to exit 32 with an unformatted error:

```
[taskcat] |Queing test => quickstart-fortigate-test-ap-southeast-2
Supported regions are ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ap-south-1', 'sa-east-1']
```
