### PR TITLE
handle new exception type added to cfn-lint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mock==2.0.0
 tabulate==0.8.2
 pyfiglet==0.7.5
-cfn_lint==0.9.0
+cfn_lint==0.9.1
 setuptools==40.4.3
 boto3==1.9.21
 botocore==1.12.21

--- a/taskcat/cfn_lint.py
+++ b/taskcat/cfn_lint.py
@@ -68,12 +68,18 @@ class Lint(object):
                 templates[template_file] = self._get_child_templates(template_file, set(), parent_path=self._path)
             lints[test]['results'] = {}
             templates[template_file].add(template_file)
+            lint_errors = set()
             for t in templates[template_file]:
                 template = self._parse_template(t, quiet=True)
                 if template:
-                    lints[test]['results'][t] = cfnlint.core.run_checks(
-                        t, template, self._rules, lints[test]['regions']
-                    )
+                    try:
+                        lints[test]['results'][t] = cfnlint.core.run_checks(
+                            t, template, self._rules, lints[test]['regions']
+                        )
+                    except cfnlint.core.CfnLintExitException as e:
+                        lint_errors.add(PrintMsg.ERROR + str(e))
+            for e in lint_errors:
+                print(e)
         return lints
 
     def output_results(self):


### PR DESCRIPTION
## Overview

handles new exception type added to cfnlint in https://github.com/awslabs/cfn-python-lint/pull/463. This should ensure that failures in the linter never result in taskcat exiting prematurely and that lint errors are correctly displayed.

## Testing/Steps taken to ensure quality

tested against several quickstarts

