### PR TITLE
better errors for bad json parameters

### DIFF
--- a/taskcat/common_utils.py
+++ b/taskcat/common_utils.py
@@ -2,6 +2,7 @@ import re
 import sys
 import os
 from taskcat.colored_console import PrintMsg
+from taskcat.exceptions import TaskCatException
 
 
 class CommonTools:
@@ -56,3 +57,20 @@ def make_dir(path, ignore_exists=True):
     if ignore_exists and os.path.isdir(path):
         return
     os.makedirs(path)
+
+
+def param_list_to_dict(original_keys):
+    # Setup a list index dictionary.
+    # - Used to give an Parameter => Index mapping for replacement.
+    param_index = {}
+    if type(original_keys) != list:
+        raise TaskCatException('Invalid parameter file, outermost json element must be a list ("[]")')
+    for (idx, param_dict) in enumerate(original_keys):
+        if type(param_dict) != dict:
+            raise TaskCatException('Invalid parameter %s parameters must be of type dict ("{}")' % param_dict)
+        if 'ParameterKey' not in param_dict or 'ParameterValue' not in param_dict:
+            raise TaskCatException(
+                'Invalid parameter %s all items must have both ParameterKey and ParameterValue keys' % param_dict)
+        key = param_dict['ParameterKey']
+        param_index[key] = idx
+    return param_index

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -49,7 +49,7 @@ from taskcat.cfn_logutils import CfnLogTools
 from taskcat.cfn_resources import CfnResourceTools
 from taskcat.exceptions import TaskCatException
 from taskcat.s3_sync import S3Sync
-from taskcat.common_utils import exit0
+from taskcat.common_utils import exit0, param_list_to_dict
 
 
 # Version Tag
@@ -310,12 +310,7 @@ class TaskCat(object):
         except Exception as e:
             pass
 
-        # Setup a list index dictionary.
-        # - Used to give an Parameter => Index mapping for replacement.
-        param_index = {}
-        for (idx, param_dict) in enumerate(original_keys):
-            key = param_dict['ParameterKey']
-            param_index[key] = idx
+        param_index = param_list_to_dict(original_keys)
 
         template_params = self.extract_template_parameters()
         # Merge the two lists, overriding the original values if necessary.

--- a/tests/unittest/test_common_utils.py
+++ b/tests/unittest/test_common_utils.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+
+import unittest
+
+from taskcat.exceptions import TaskCatException
+from taskcat.common_utils import param_list_to_dict
+
+
+class TestCfnLogTools(unittest.TestCase):
+
+    def test_get_param_includes(self):
+        bad_testcases = [
+            {},
+            [[]],
+            [{}]
+        ]
+        for bad in bad_testcases:
+            with self.assertRaises(TaskCatException):
+                param_list_to_dict(bad)


### PR DESCRIPTION
## Overview

Improve the error feedback when we fail to parse a parameters json file. 

Fixes #201

## Testing/Steps taken to ensure quality

tested against various bad and good json params

### Notes

Wrote tests to fail, refactored, coded till tests passed. I think this pr is a nice simple example of how we should be using TDD to incrementally improve the codebase, reduce risk of regressions and improve test coverage.

## Testing Instructions

invalid parameter files should exit 1 with meaningful errors.
