### PR TITLE
Allow partial substitution in random string tokens. 

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -792,7 +792,7 @@ class TaskCat(object):
 
                 # Determines if random string  value was requested
                 gen_string_re = re.compile(
-                    '\$\[taskcat_random-string]$', re.IGNORECASE)
+                    '.*\$\[taskcat_random-string].*', re.IGNORECASE)
 
                 # Determines if random number value was requested
                 gen_numbers_re = re.compile(
@@ -844,6 +844,8 @@ class TaskCat(object):
                 if gen_string_re.search(param_value):
                     random_string = self.regxfind(gen_string_re, param_value)
                     param_value = self.generate_random('alpha', 20)
+
+                    param_value = random_string.replace("$[taskcat_random-string]", param_value)
 
                     if self.verbose:
                         print("{}Generating random string for {}".format(PrintMsg.DEBUG, random_string))


### PR DESCRIPTION
Pull request to allow partial substitution in random string tokens.  For example: "$[taskcat_random-string].t.quickstart.awspartner.com" should only replace the token part of it.

## Overview

Brief description of what this PR does, and why it is needed (use case)?

Right now random string substitution replaces the whole token, it works well for cases where you need a totally random value but doesn't work when you want to only partially substitute. A good example of this is cases where you need to generate a random Route53 record set entry but the root DNS needs to be preserved.

This change is backwards compatible. If the parameter value in input is just `$[taskcat_random-string]` token, then the whole value gets replaced. When the parameter value has prefix and suffix strings, only the token gets replaced, leaving the prefix and suffix intact.

e.g. `my-qs-$[taskcat_random-string]-example.com` will become 
`my-qs-yysuawpwubvotiqgwjcu-example.com`.

