### PR TITLE
Return specific AZ's for taskcat_getsingleaz

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -830,7 +830,7 @@ class TaskCat(object):
                 genaz_re = re.compile('\$\[\w+_ge[nt]az_\d]', re.IGNORECASE)
 
                 # Determines if single AZ has been requested. This is added to support legacy templates
-                genaz_single_re = re.compile('\$\[\w+_ge[nt]singleaz_\d]', re.IGNORECASE)
+                genaz_single_re = re.compile('\$\[\w+_ge[nt]singleaz_(?P<az_id>\d+)]', re.IGNORECASE)
 
                 # Determines if uuid has been requested
                 genuuid_re = re.compile('\$\[\w+_gen[gu]uid]', re.IGNORECASE)
@@ -1007,19 +1007,13 @@ class TaskCat(object):
                         _parameters['ParameterValue'] = param_value
 
                 if genaz_single_re.search(param_value):
-                    az_id = int(
-                        self.regxfind(count_re, param_value))
-                    if az_id:
-                        print(PrintMsg.DEBUG + "Requested 1 az")
-                        print(PrintMsg.DEBUG + "Selecting availability zone %s" % az_id)
-                        param_value = self.get_single_az(region, az_id)
-                        _parameters['ParameterValue'] = param_value
-                    else:
-                        print(PrintMsg.INFO + "$[taskcat_getsingleaz_(!)]")
-                        print(PrintMsg.INFO + "Which az not specified!")
-                        print(PrintMsg.INFO + " - (Defaulting to az 1)")
-                        param_value = self.get_single_az(region, 1)
-                        _parameters['ParameterValue'] = param_value
+                    re_match = genaz_single_re.search(param_value)
+                    az_id = int(re_match.group('az_id'))
+
+                    print(PrintMsg.DEBUG + "Requested 1 az")
+                    print(PrintMsg.DEBUG + "Selecting availability zone %s" % az_id)
+                    param_value = self.get_single_az(region, az_id)
+                    _parameters['ParameterValue'] = param_value
 
                 self.set_parameter(param_key, param_value)
 


### PR DESCRIPTION
Looking at a few different repos, it appears that the expected functionality of the `taskcat_getsingleaz` substitution differs from its actual implementation. Currently this will always return a single AZ as expected, but always the first AZ as returned from the API lookup.

This change allows template parameters to select specific AZ's by index, which seems to match the intended usage.

## Overview

It appears that this was intended to allow a template's parameters to select availability zones without knowing what they are. CloudFormation provides this as a pseudo-parameter mapping, but it may make more sense to allow users to specify availability zones at launch time. In this case, taskcat needs a similar kind of mapping lookup.

For multiple examples, see the various compliance-* repos. Here's the PCI compliance Quick Start's parameters: https://github.com/aws-quickstart/quickstart-compliance-pci/blob/master/ci/defaults.json

## Testing/Steps taken to ensure quality

Tested locally using templates with substitution's similar to `taskcat_getsingleaz_1`, `taskcat_getsingleaz_2`, etc.

## Testing Instructions

Test 1:
  * Create taskcat `defaults.json` parameters file that uses the `$[taskcat_getsingleaz_1]` and `$[taskcat_getsingleaz_2]` substitutions.
  * Run taskcat and check that the template parameters are properly filled in with the first and second AZ's from the region

Test 2:
  * Try using an invalid index for the AZ, such as `$[taskcat_getsingleaz_100]`
  * Run taskcat and check that it exits with an error stating that there are not that many AZ's in the region