### PR TITLE
Ensure TaskCat returns exit code 1 if stack fails.

### DIFF
--- a/bin/taskcat
+++ b/bin/taskcat
@@ -95,6 +95,8 @@ def main():
             tcat_instance.get_stackstatus(testdata, 5)
             tcat_instance.createreport(testdata, 'index.html')
             tcat_instance.cleanup(testdata, 5)
+            if tcat_instance.one_or_more_tests_failed:
+                exit1("One or more tests failed. See the report for details.")
     except taskcat.exceptions.TaskCatException as e:
         print(taskcat.PrintMsg.ERROR + str(e))
         exit1(str(e))

--- a/taskcat/generate_reports.py
+++ b/taskcat/generate_reports.py
@@ -47,6 +47,7 @@ class ReportBuilder:
                         status_css = 'class=test-green'
                     elif rstatus == 'CREATE_FAILED':
                         status_css = 'class=test-red'
+                        self.taskcat.one_or_more_tests_failed = True
                         if self.taskcat.retain_if_failed and (self.taskcat.run_cleanup == True):
                             self.taskcat.run_cleanup = False
                     else:

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -315,16 +315,14 @@ class TaskCat(object):
 
         template_params = self.extract_template_parameters()
         # Merge the two lists, overriding the original values if necessary.
-        for override in dict_squash_list:
-            for override_pd in override:
-                key = override_pd['ParameterKey']
-                if key in param_index.keys():
-                    idx = param_index[key]
-                    original_keys[idx] = override_pd
-                elif key in template_params:
-                    original_keys.append(override_pd)
-                else:
-                    print(PrintMsg.INFO + "Cannot override [{}]! It's not present within the template!".format(key))
+            for override in dict_squash_list:
+                for override_pd in override:
+                    key = override_pd['ParameterKey']
+                    if key in param_index.keys():
+                        idx = param_index[key]
+                        original_keys[idx] = override_pd
+                    else:
+                        print(PrintMsg.INFO + "Cannot apply overrides for the [{}] Parameter. You did not include this parameter in [{}]".format(key, self.get_parameter_file()))
 
         # check if s3 bucket and QSS3BucketName param match. fix if they dont.
         bucket_name = self.get_s3bucket()

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -466,6 +466,12 @@ class TaskCat(object):
         if self.upload_only:
             exit0("Upload completed successfully")
 
+    def remove_public_acl_from_bucket(self):
+        if self.public_s3_bucket:
+            print(PrintMsg.INFO + "The S3 Bucket was created with public-read permissions. They're no longer needed. Removing.")
+            s3_client = self._boto_client.get('s3', region=self.get_default_region(), s3v4=True)
+            s3_client.put_bucket_acl(Bucket=self.s3bucket, ACL='private')
+
     def get_content(self, bucket, object_key):
         """
         Returns the content of an object, given the bucket name and the key of the object
@@ -979,6 +985,7 @@ class TaskCat(object):
             while deleting the stacks.
 
         """
+        self.remove_public_acl_from_bucket()
 
         docleanup = self.get_docleanup()
         if self.verbose:

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -193,6 +193,7 @@ class TaskCat(object):
         self.upload_only = False
         self._max_bucket_name_length = 63
         self.lambda_build_only = False
+        self.one_or_more_tests_failed = False
 
         # SETTERS ANPrintMsg.DEBUG GETTERS
     # ===================

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -468,7 +468,7 @@ class TaskCat(object):
 
     def remove_public_acl_from_bucket(self):
         if self.public_s3_bucket:
-            print(PrintMsg.INFO + "The S3 Bucket was created with public-read permissions. They're no longer needed. Removing.")
+            print(PrintMsg.INFO + "The staging bucket [{}] should be only required during cfn bootstrapping. Removing public permission as they are no longer needed!".format(self.s3bucket))
             s3_client = self._boto_client.get('s3', region=self.get_default_region(), s3v4=True)
             s3_client.put_bucket_acl(Bucket=self.s3bucket, ACL='private')
 

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -315,14 +315,14 @@ class TaskCat(object):
 
         template_params = self.extract_template_parameters()
         # Merge the two lists, overriding the original values if necessary.
-            for override in dict_squash_list:
-                for override_pd in override:
-                    key = override_pd['ParameterKey']
-                    if key in param_index.keys():
-                        idx = param_index[key]
-                        original_keys[idx] = override_pd
-                    else:
-                        print(PrintMsg.INFO + "Cannot apply overrides for the [{}] Parameter. You did not include this parameter in [{}]".format(key, self.get_parameter_file()))
+        for override in dict_squash_list:
+            for override_pd in override:
+                key = override_pd['ParameterKey']
+                if key in param_index.keys():
+                    idx = param_index[key]
+                    original_keys[idx] = override_pd
+                else:
+                    print(PrintMsg.INFO + "Cannot apply overrides for the [{}] Parameter. You did not include this parameter in [{}]".format(key, self.get_parameter_file()))
 
         # check if s3 bucket and QSS3BucketName param match. fix if they dont.
         bucket_name = self.get_s3bucket()


### PR DESCRIPTION
This PR returns an exit code of 1 if any test fails. This ensures Taskcat is compliant with expected behavior as a standalone utility in build pipelines.

Testing done: Verified proper return code from `sample-taskcat-project`; log output below. 

Upstream dependencies: #230 #232 

```
taskcat/examples on  issues/223 [$✘!?] via taskcat-development
➜ python3 $(pwd)/../bin/taskcat -c sample-taskcat-project/ci/taskcat-autobucket.yml

(...)

[INFO   ] :AWS REGION      CLOUDFORMATION STACK STATUS [CLOUDFORMATION STACK NAME]
[INFO   ] :us-east-1       STACK_DELETED             [tCaT-tag-taskcat-json-4e431e84]
[INFO   ] :us-east-1       STACK_DELETED             [tCaT-tag-taskcat-yaml-4e431e84]


[INFO   ] :All stacks deleted successfully. Deep clean-up not required.
[INFO   ] :All stacks deleted successfully. Deep clean-up not required.
[INFO   ] :(Cleaning up staging assets)
[INFO   ] :Deleted 10 objects from taskcat-tag-sample-taskcat-project-4e431e84
[DEBUG  ] :Deleting Bucket taskcat-tag-sample-taskcat-project-4e431e84
[ERROR  ] :One or more tests failed. See the report for details.

taskcat/examples on  issues/223 [$✘!?] via taskcat-development took 49s
➜ echo $?
1
```