### PR TITLE
Revert "Little Typo fix"

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1363,7 +1363,7 @@ class TaskCat(object):
         ]
         try:
             if os.path.isfile(yaml_file):
-                print(self.nametag + " :Reading Config from: {0}".format(yaml_file))
+                print(self.nametag + " :Reading Config form: {0}".format(yaml_file))
                 with open(yaml_file, 'r') as checkyaml:
                     cfg_yml = yaml.safe_load(checkyaml.read())
                     for key in required_global_keys:


### PR DESCRIPTION
Reverts aws-quickstart/taskcat#247 Wrong target branch
