### PR TITLE
upgrading cfn-lint version to v0.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mock==2.0.0
 tabulate==0.8.2
 pyfiglet==0.7.5
-cfn_lint==0.9.1
+cfn_lint==0.13.0
 setuptools==40.4.3
 boto3==1.9.21
 botocore==1.12.21


### PR DESCRIPTION
## Overview

Ensure taskcat is compatible with latest Cloudformation schemas. In my case, trying to get past newly available `UpdateReplacePolicy` resource policy.

## Testing/Steps taken to ensure quality

Tested `taskcat==0.8.24` locally with `cfn-lint==0.13.0`.

