### PR TITLE
upgrading cfn-lint version to v0.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mock==2.0.0
 tabulate==0.8.2
 pyfiglet==0.7.5
-cfn_lint==0.12.1
+cfn_lint==0.13.0
 setuptools==40.4.3
 boto3==1.9.21
 botocore==1.12.21


### PR DESCRIPTION
## Overview

This is to ensure we can use taskcat with templates using the latest CloudFormation schemas.

## Testing/Steps taken to ensure quality

In my case, I am trying to use the latest `UpdateReplacePolicy` resource policy. I successfully tested taskcat run with `cfn-lint==0.13.0`.