### PR TITLE
BugFix - KeyError when testing templates with no parameters

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -554,11 +554,15 @@ class TaskCat(object):
 
     def extract_template_parameters(self):
         """
-        Returns a dictionary of the parameters in the template entrypoint.
+        Returns a dictionary of the parameters in the template entrypoint, if it exist.
+        Otherwise, return empty {} dictionary if there are no parameters in the template.
 
         :return: list of parameters for the template.
         """
-        return self.template_data['Parameters'].keys()
+        if 'Parameters' in self.template_data:
+            return self.template_data['Parameters'].keys()
+        else:
+            return {}
 
     def validate_template(self, taskcat_cfg, test_list):
         """


### PR DESCRIPTION
## Overview

This PR fixes the issue where Taskcat fails with _KeyError[Parameters]_ when 'Parameters'_ section is missing in the template. This fix will allow to use Taskcat for templates without parameters.

## Testing/Steps taken to ensure quality

Tested with templates with and without parameters.
