### PR TITLE
[wip] Add --exclude param for paths or files

### DIFF
--- a/taskcat/common_utils.py
+++ b/taskcat/common_utils.py
@@ -1,3 +1,4 @@
+import fnmatch
 import re
 import sys
 import os
@@ -50,6 +51,31 @@ def exit0(msg=''):
     if msg:
         print(PrintMsg.INFO + msg)
     sys.exit(0)
+
+
+def normalize_paths(paths):
+  result = set()
+  for path in paths:
+    if(os.path.isdir(path)):
+      if not path.startswith('./'):
+        path = './' + path
+      if not path.endswith('*'):
+        path = path + '*'
+    result.add(path)
+  return list(result)
+
+
+def get_file_list(basepath, exclusions):
+  files = set()
+  to_exclude = set()
+  for root, dirnames, filenames in os.walk(basepath):
+    for filename in filenames:
+      files.add(os.path.join(root, filename))
+
+  for exclusion in normalize_paths(exclusions):
+    for filename in fnmatch.filter(list(files), exclusion):
+      to_exclude.add(filename)
+  return [x for x in files if x not in to_exclude]
 
 
 def make_dir(path, ignore_exists=True):

--- a/taskcat/common_utils.py
+++ b/taskcat/common_utils.py
@@ -67,15 +67,13 @@ def normalize_paths(paths):
 
 def get_file_list(basepath, exclusions):
   files = set()
-  to_exclude = set()
   for root, dirnames, filenames in os.walk(basepath):
-    for filename in filenames:
-      files.add(os.path.join(root, filename))
-
-  for exclusion in normalize_paths(exclusions):
-    for filename in fnmatch.filter(list(files), exclusion):
-      to_exclude.add(filename)
-  return [x for x in files if x not in to_exclude]
+    filepaths = [os.path.join(root, filename) for filename in filenames]
+    to_exclude = set()
+    for exclusion in normalize_paths(exclusions):
+      to_exclude.update(fnmatch.filter(filepaths, exclusion))
+    files.update([x for x in filepaths if x not in to_exclude])
+  return list(files)
 
 
 def make_dir(path, ignore_exists=True):

--- a/taskcat/s3_sync.py
+++ b/taskcat/s3_sync.py
@@ -9,7 +9,6 @@
 from __future__ import print_function
 
 import hashlib
-import fnmatch
 import os
 import time
 from functools import partial

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -195,8 +195,9 @@ class TaskCat(object):
         self._max_bucket_name_length = 63
         self.lambda_build_only = False
         self.one_or_more_tests_failed = False
+        self.exclude = []
 
-        # SETTERS ANPrintMsg.DEBUG GETTERS
+    # SETTERS ANPrintMsg.DEBUG GETTERS
     # ===================
 
     def set_project_name(self, project_name):
@@ -265,6 +266,9 @@ class TaskCat(object):
 
     def set_parameter_file(self, parameter):
         self._parameter_file = parameter
+
+    def get_exclude(self):
+        return self.exclude
 
     def get_parameter_file(self):
         return self._parameter_file
@@ -457,7 +461,7 @@ class TaskCat(object):
                     Tagging={"TagSet": self.tags}
                 )
 
-        S3Sync(s3_client, self.get_s3bucket(), self.get_project_name(), self.get_project_path(), bucket_or_object_acl)
+        S3Sync(s3_client, self.get_s3bucket(), self.get_project_name(), self.get_project_path(), self.get_exclude(), bucket_or_object_acl)
         self.s3_url_prefix = "https://" + self.get_s3_hostname() + "/" + self.get_project_name()
         if self.upload_only:
             exit0("Upload completed successfully")
@@ -1546,6 +1550,12 @@ class TaskCat(object):
             '--lambda-build-only',
             action='store_true',
             help="create lambda zips and exit")
+        parser.add_argument(
+            '-e',
+            '--exclude',
+            action='append',
+            help="Exclude directory or files from s3 sync"
+        )
 
         args = parser.parse_args()
 
@@ -1571,6 +1581,11 @@ class TaskCat(object):
 
         try:
             self.tags = args.tags
+        except AttributeError:
+            pass
+
+        try:
+            self.exclude = args.exclude
         except AttributeError:
             pass
 

--- a/tests/unittest/test_common_utils.py
+++ b/tests/unittest/test_common_utils.py
@@ -67,11 +67,11 @@ class TestGetFileList(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_get_exclude_normalized_folder_with_wildcard_and_hidden_files(self):
-        result = execute(['./foo/baz/*', '*/.*'], [True, False])
+        result = execute(['./foo/baz/*', '*/.*'], [False, False])
         expected = ['./foo/bar']
         self.assertEqual(result, expected)
 
     def test_get_exclude_folder_and_js_files(self):
-        result = execute(['foo/.git*', '*.js'], [True, False])
+        result = execute(['foo/.git*', '*.js'], [False, False])
         expected = ['./foo/bar', './foo/baz/.hidden', './foo/baz/b.yaml', './foo/baz/c.txt']
         self.assertEqual(result, expected)

--- a/tests/unittest/test_common_utils.py
+++ b/tests/unittest/test_common_utils.py
@@ -1,9 +1,25 @@
 from __future__ import print_function
 
+import mock
 import unittest
 
 from taskcat.exceptions import TaskCatException
 from taskcat.common_utils import param_list_to_dict
+from taskcat.common_utils import get_file_list
+    
+def execute(exclusions, dirs):
+    os_walk_mock = [
+        ('./foo', ('.git', 'baz'), ('.gitignore', 'bar')),
+        ('./foo/.git', (), ('file1', 'file2')),
+        ('./foo/baz', (), ('a.js', 'b.yaml', '.hidden', 'c.txt', 'd.js'))
+    ]
+    with mock.patch('os.walk') as mockwalk:
+        mockwalk.return_value = os_walk_mock
+        with mock.patch('os.path.isdir') as mockisdir:
+            mockisdir.return_value = dirs
+            result = get_file_list('.', exclusions)
+            result.sort()
+            return result
 
 
 class TestCfnLogTools(unittest.TestCase):
@@ -17,3 +33,45 @@ class TestCfnLogTools(unittest.TestCase):
         for bad in bad_testcases:
             with self.assertRaises(TaskCatException):
                 param_list_to_dict(bad)
+
+class TestGetFileList(unittest.TestCase):
+
+    def test_get_exclude_hidden_files(self):
+        result = execute(['*/.*'], [False])
+        expected = ['./foo/bar', './foo/baz/a.js', './foo/baz/b.yaml', './foo/baz/c.txt', './foo/baz/d.js']
+        self.assertEqual(result, expected)
+
+    def test_get_exclude_js_files(self):
+        result = execute(['*.js'], [False])
+        expected = ['./foo/.git/file1', './foo/.git/file2', './foo/.gitignore', './foo/bar', './foo/baz/.hidden', './foo/baz/b.yaml', './foo/baz/c.txt']
+        self.assertEqual(result, expected)
+
+    def test_get_exclude_hidden_and_js_files(self):
+        result = execute(['*.js', '*/.*'], [False, False])
+        expected = ['./foo/bar', './foo/baz/b.yaml', './foo/baz/c.txt']
+        self.assertEqual(result, expected)
+
+    def test_get_exclude_unnormalized_folder_and_hidden_files(self):
+        result = execute(['foo/baz', '*/.*'], [True, False])
+        expected = ['./foo/bar']
+        self.assertEqual(result, expected)
+
+    def test_get_exclude_unnormalized_folder_with_wildcard_and_hidden_files(self):
+        result = execute(['foo/baz/*', '*/.*'], [False, False])
+        expected = ['./foo/bar']
+        self.assertEqual(result, expected)
+
+    def test_get_exclude_normalized_folder_and_hidden_files(self):
+        result = execute(['./foo/baz', '*/.*'], [True, False])
+        expected = ['./foo/bar']
+        self.assertEqual(result, expected)
+
+    def test_get_exclude_normalized_folder_with_wildcard_and_hidden_files(self):
+        result = execute(['./foo/baz/*', '*/.*'], [True, False])
+        expected = ['./foo/bar']
+        self.assertEqual(result, expected)
+
+    def test_get_exclude_folder_and_js_files(self):
+        result = execute(['foo/.git*', '*.js'], [True, False])
+        expected = ['./foo/bar', './foo/baz/.hidden', './foo/baz/b.yaml', './foo/baz/c.txt']
+        self.assertEqual(result, expected)


### PR DESCRIPTION
## Overview

Adds an exclude param as discussed in #68 
At the moment, it supports normalized and non-normalized paths, and wildcards such as 
`--exclude foo` or `--exclude ./foo`, `--exclude *.txt`. It also supports multiple `--exclude` params.

NOTE:
In the issue, we discussed about both adding a parameter and a .taskcatignore file for similar behavior. I decided I'll work on the .taskcatignore change separately to keep the PR small - much of what's here can definitely be reused for that.

## Testing/Steps taken to ensure quality

* Added some unit tests for the function that works out the folder structure
* Manually tested with https://github.com/aws-samples/amazon-rekognition-engagement-meter
