### PR TITLE
Exclude bugfix

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -1596,7 +1596,8 @@ class TaskCat(object):
             pass
 
         try:
-            self.exclude = args.exclude
+            if args.exclude is not None:
+                self.exclude = args.exclude
         except AttributeError:
             pass
 


### PR DESCRIPTION
## Overview

Fixes a bug introduced with #261.
When no exclude param is provided, this exception is raised:
```
Traceback (most recent call last):
  File "/Users/mfigus/.pyenv/versions/3.7.1/bin/taskcat", line 4, in <module>
    __import__('pkg_resources').run_script('taskcat==0.8.27', 'taskcat')
  File "/Users/mfigus/.local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 661, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/Users/mfigus/.local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1441, in run_script
    exec(code, namespace, namespace)
  File "/Users/mfigus/.pyenv/versions/3.7.1/lib/python3.7/site-packages/taskcat-0.8.27-py3.7.egg/EGG-INFO/scripts/taskcat", line 101, in <module>
    main()
  File "/Users/mfigus/.pyenv/versions/3.7.1/lib/python3.7/site-packages/taskcat-0.8.27-py3.7.egg/EGG-INFO/scripts/taskcat", line 84, in main
    tcat_instance.stage_in_s3(taskcat_cfg)
  File "/Users/mfigus/.pyenv/versions/3.7.1/lib/python3.7/site-packages/taskcat-0.8.27-py3.7.egg/taskcat/stacker.py", line 464, in stage_in_s3
    for exclude in self.get_exclude():
TypeError: 'NoneType' object is not iterable
```

## Testing/Steps taken to ensure quality

Manually tested with no param provided.

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output
