### PR TITLE
Moving cfg under taskcat dir

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 recursive-include taskcat/project_templates *
+recursive-include taskcat/cfg *


### PR DESCRIPTION
This moves the previously-committed `cfg` dir under `taskcat/`, so it's included with the package data. 