### PR TITLE
disable sigv2 on ephemeral buckets by default

### DIFF
--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -460,6 +460,25 @@ class TaskCat(object):
                     Bucket=auto_bucket,
                     Tagging={"TagSet": self.tags}
                 )
+            policy = """{
+   "Version": "2012-10-17",
+   "Statement": [
+         {
+               "Sid": "Test",
+               "Effect": "Deny",
+               "Principal": "*",
+               "Action": "s3:*",
+               "Resource": "arn:aws:s3:::%s/*",
+               "Condition": {
+                     "StringEquals": {
+                           "s3:signatureversion": "AWS"
+                     }
+               }
+         }
+   ]
+}
+""" % auto_bucket
+            s3_client.put_bucket_policy(Bucket=auto_bucket, Policy=policy)
 
         for exclude in self.get_exclude():
             if(os.path.isdir(exclude)):


### PR DESCRIPTION
## Overview

Clients accessing ephemeral buckets should always use sigv4

## Testing/Steps taken to ensure quality

```
taskcat -c ci/taskcat.yml -u
ipython
In [1]: import boto3
In [2]: s = boto3.client('s3', config=boto3.session.Config(signature_version='s3'))
In [3]: s.get_object(Bucket='taskcat-tag-quickstart-redhat-openshift-b8f5dc82', Key='quickstart-redhat-openshift/templates/openshift.template')  
...
ClientError: An error occurred (AccessDenied) when calling the GetObject operation: Access Denied

In [4]: s = boto3.client('s3', config=boto3.session.Config(signature_version='s3v4'))                                                            
In [5]: s.get_object(Bucket='taskcat-tag-quickstart-redhat-openshift-b8f5dc82', Key='quickstart-redhat-openshift/templates/openshift.template')  
Out[5]: 
{'ResponseMetadata': {'RequestId': 'ttt',
  'HostId': 'yyy',
  'HTTPStatusCode': 200,
  'HTTPHeaders': {'x-amz-id-2': 'xxx',
   'x-amz-request-id': 'ttt',
   'date': 'Wed, 24 Apr 2019 00:04:48 GMT',
   'last-modified': 'Tue, 23 Apr 2019 23:57:56 GMT',
   'etag': '"zzz"',
   'accept-ranges': 'bytes',
   'content-type': 'binary/octet-stream',
   'content-length': '74926',
   'server': 'AmazonS3'},
  'RetryAttempts': 0},
 'AcceptRanges': 'bytes',
 'LastModified': datetime.datetime(2019, 4, 23, 23, 57, 56, tzinfo=tzutc()),
 'ContentLength': 74926,
 'ETag': '"zzz"',
 'ContentType': 'binary/octet-stream',
 'Metadata': {},
 'Body': <botocore.response.StreamingBody at 0x10ee9ac88>}
```