### PR TITLE
Adding regional cred granularity to ClientFactory

### DIFF
--- a/taskcat/client_factory.py
+++ b/taskcat/client_factory.py
@@ -34,7 +34,8 @@ class ClientFactory(object):
     """
 
     def __init__(self, logger=None, loglevel='error', botolevel='error', aws_access_key_id=None,
-                 aws_secret_access_key=None, aws_session_token=None, profile_name=None):
+                 aws_secret_access_key=None, aws_session_token=None, profile_name=None,
+                 regional_cred_map={}):
         """Sets up the cache dict, a locking mechanism and the logging object
 
         Args:
@@ -64,6 +65,9 @@ class ClientFactory(object):
         else:
             self.logger = logger
         self.put_credential_set('default', aws_access_key_id, aws_secret_access_key, aws_session_token, profile_name)
+        for region_name, credential_dict in regional_cred_map.items():
+            self.put_credential_set(region_name, **credential_dict)
+
         return
 
     def get_default_region(self, aws_access_key_id, aws_secret_access_key, aws_session_token, profile_name):
@@ -139,6 +143,8 @@ class ClientFactory(object):
             )
             if credential_set not in self._credential_sets.keys():
                 raise KeyError('credential set %s does not exist' % credential_set)
+            if region and region in self._credential_sets.keys():
+                credential_set = region
             aws_access_key_id, aws_secret_access_key, aws_session_token, profile_name = self._credential_sets[
                 credential_set]
         if not region:

--- a/tests/unittest/test_client_factory.py
+++ b/tests/unittest/test_client_factory.py
@@ -302,6 +302,16 @@ class TestClientFactory(unittest.TestCase):
         s = aws_clients.get_session("default", "us-east-2")
         self.assertEqual(ue2_session, s, msg)
 
+    @mock.patch("taskcat.ClientFactory._create_client", mock.MagicMock(return_value=MockClient()))
+    @mock.patch("taskcat.ClientFactory._create_session", mock.MagicMock(return_value=MockBotoSessionClass()))
+    def test_regional_cred_map(self):
+        aws_clients = ClientFactory(regional_cred_map={'ap-east-1': {'profile_name': 'blah'}})
+        self.assertEquals(aws_clients._credential_sets['ap-east-1'], [None, None, None, 'blah'])
+        self.assertEquals(aws_clients._credential_sets['default'], [None, None, None, None])
+
+        ClientFactory._create_client.reset_mock()
+        aws_clients.get("test_service", region='ap-east-1')
+        ClientFactory._create_client.assert_called_once_with('ap-east-1', 'ap-east-1', 'test_service', 'default_sig_version')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

Adds the `regional_cred_map` dictionary to ClientFactory. Expects a dict in this format:
```
{
  <region> : {
    'aws_access_key_id' / 'profile_name' / ...
   }
}
```

This is useful in environments that manage deployments across multiple accounts. Rather than run multiple seperate taskcat/amiupdater/(other tool) invocations, credentials can be customized to suit individual use-cases. 

## Testing/Steps taken to ensure quality

ad-hoc tests. 

```
bpython version 0.17.1 on top of Python 3.7.3 /usr/local/opt/python/bin/python3.7
>>> from client_factory import ClientFactory
>>> regional_cred_map = {'ap-east-1':{'profile_name':'andrew-hongkong'}}
>>> from client_factory import ClientFactory
>>> regional_cred_map = {'ap-east-1':{'profile_name':'andrew-hongkong'}}
>>> cf = ClientFactory(regional_cred_map=regional_cred_map)
>>> ec2_default = cf.get('ec2')
>>> ec2_hongkong = cf.get('ec2', region='ap-east-1')
>>> ec2_default_regions = ec2_default.describe_regions()
>>> ec2_hongkong_regions = ec2_hongkong.describe_regions()
>>> [x['RegionName'] for x in ec2_default_regions['Regions']]
['eu-north-1', 'ap-south-1', 'eu-west-3', 'eu-west-2', 'eu-west-1', 'ap-northeast-3', 'ap-northeast-2', 'ap-northeast-1', 'sa-east-1', 'ca-central-1', 'ap-southeast-1', 'ap-so
1', 'us-west-2']
>>> [x['RegionName'] for x in ec2_hongkong_regions['Regions']]
['eu-north-1', 'ap-south-1', 'eu-west-3', 'eu-west-2', 'eu-west-1', 'ap-northeast-3', 'ap-northeast-2', 'ap-northeast-1', 'sa-east-1', 'ca-central-1', 'ap-east-1', 'ap-southea
2', 'us-west-1', 'us-west-2']
>>> cf._credential_sets
{'default': [None, None, None, None], 'ap-east-1': [None, None, None, 'andrew-hongkong']}
>>>
```