### PR TITLE
AMIUpdater: Custom exception for no filters; exiting 0; tests

### DIFF
--- a/bin/amiupdater
+++ b/bin/amiupdater
@@ -2,7 +2,7 @@
 import sys
 import os
 import argparse
-from taskcat.amiupdater import AMIUpdater, AMIUpdaterFatalException, AMIUpdaterCommitNeededException
+from taskcat.amiupdater import AMIUpdater, AMIUpdaterFatalException, AMIUpdaterCommitNeededException, AMIUpdaterNoFiltersException
 from taskcat.colored_console import PrintMsg
 
 def exit(code):
@@ -48,3 +48,5 @@ if __name__ == "__main__":
             exit(100)
         except AMIUpdaterFatalException:
             exit(1)
+        except AMIUpdaterNoFiltersException:
+            exit(0)

--- a/taskcat/amiupdater.py
+++ b/taskcat/amiupdater.py
@@ -17,7 +17,14 @@ from multiprocessing.dummy import Pool as ThreadPool
 
 class AMIUpdaterFatalException(TaskCatException):
     """Raised when AMIUpdater experiences a fatal error"""
-    pass
+    def __init__(self, message=None):
+        if message:
+            print("{} {}".format(PrintMsg.ERROR, message))
+
+class AMIUpdaterNoFiltersException(TaskCatException):
+    def __init__(self, message=None):
+        if message:
+            print("{} {}".format(PrintMsg.ERROR, message))
 
 class AMIUpdaterCommitNeededException(TaskCatException):
     pass
@@ -131,7 +138,7 @@ class Codenames:
         # Create a ThreadPool, size is the number of regions.
 
         if len(RegionalCodename.objects()) == 0:
-            raise AMIUpdaterFatalException("No AMI filters were found. Nothing to fetch from the EC2 API.")
+            raise AMIUpdaterNoFiltersException("No AMI filters were found. Nothing to fetch from the EC2 API.")
 
         pool = ThreadPool(len(TemplateClass.regions()))
         # For reach RegionalCodename that we've generated....

--- a/tests/unittest/test_amiupdater.py
+++ b/tests/unittest/test_amiupdater.py
@@ -794,15 +794,17 @@ class MockEC2:
 
 class TestAMIUpdater(unittest.TestCase):
 
-    def _module_loader(self, return_module=False, commit_needed=False):
+    def _module_loader(self, return_module=False, commit_needed=False, no_filters=False):
         try:
             del sys.modules['taskcat.amiupdater']
         except KeyError:
             pass
-        from taskcat.amiupdater import AMIUpdater, AMIUpdaterFatalException, AMIUpdaterCommitNeededException
+        from taskcat.amiupdater import AMIUpdater, AMIUpdaterFatalException, AMIUpdaterCommitNeededException, AMIUpdaterNoFiltersException
         module_tuple = (AMIUpdater, AMIUpdaterFatalException)
         if commit_needed:
             module_tuple += (AMIUpdaterCommitNeededException,)
+        if no_filters:
+            module_tuple += (AMIUpdaterNoFiltersException,)
         if return_module:
             import taskcat.amiupdater
             module_tuple += (taskcat.amiupdater,)
@@ -1101,7 +1103,7 @@ class TestAMIUpdater(unittest.TestCase):
         self.assertRaises(AMIUpdaterFatalException, a.update_amis)
 
     def test_no_filters_exception(self):
-        au, AMIUpdaterFatalException = self._module_loader()
+        au, _, AMIUpdaterNoFiltersException = self._module_loader(no_filters=True)
         cf = self.client_factory_handler()
         template_file = self.create_ephemeral_template()
         amiupdater_args = {
@@ -1110,7 +1112,7 @@ class TestAMIUpdater(unittest.TestCase):
             "client_factory": cf
         }
         a = au(**amiupdater_args)
-        self.assertRaises(AMIUpdaterFatalException, a.update_amis)
+        self.assertRaises(AMIUpdaterNoFiltersException, a.update_amis)
 
     def test_APIResults_lessthan_comparison_standard(self):
         from taskcat.amiupdater import APIResultsData


### PR DESCRIPTION
This PR adds a custom exception in the event of a template with no filters found. This exists 0, versus triggering a FatalException. The use case is for CI/CD pipelines where no filters found isn't a fatal error and the pipeline wishes to proceed further. 

Tests modified accordingly. 