### PR TITLE
Added product code for CentOS 7 AMI

### DIFF
--- a/taskcat/cfg/amiupdater.cfg.yml
+++ b/taskcat/cfg/amiupdater.cfg.yml
@@ -33,10 +33,12 @@ global:
     CENTOS7:
       name: CentOS Linux 7 x86_64 HVM EBS*
       owner-alias: aws-marketplace
+      product-code: aw0evgkw8e5c1q413zgy5pjce
       product-code.type: marketplace
     CENTOS7HVM:
       name: CentOS Linux 7 x86_64 HVM EBS*
       owner-alias: aws-marketplace
+      product-code: aw0evgkw8e5c1q413zgy5pjce
       product-code.type: marketplace
     RHEL66HVM:
       name: RHEL-6.6_HVM_GA-????????-x86_64-?-Hourly2-GP2


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed (use case)?
Added product code (aw0evgkw8e5c1q413zgy5pjce) for CentOS 7 AMI. Otherwise it is pulling a newer AMI with the same name but a different code (f7hh9b6i4gjxl02w2umkoyu5)