### PR TITLE
Update cfn_lint dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mock>=2.0.0,<3.0
 tabulate>=0.8.2,<1.0
 pyfiglet>=0.7.5,<1.0
-cfn_lint>=0.13.0,<1.0
+cfn_lint>=0.23.3,<1.0
 setuptools>=40.4.3
 boto3>=1.9.21,<2.0
 yattag>=1.10.0,<2.0


### PR DESCRIPTION
## Overview

This updates cfn_lint from 0.13.0 to 0.23.3, so that linting works for newly supported services, such as Amazon Managed Blockchain.

## Testing/Steps taken to ensure quality

I ran `python setup.py test` both before and after my changes and saw no alteration in the results. However, I am experiencing a broken test that appears to be unrelated:

    test_genaz_raises_taskcat_exception (test_template_params.TestParamGen) ... [ERROR  ] :!Only 1 az's are available in us-east-1

I submitted this as Issue #321.