### PR TITLE
Remove @ character from randomly generated passwords

### DIFF
--- a/taskcat/template_params.py
+++ b/taskcat/template_params.py
@@ -193,7 +193,7 @@ class ParamGen:
         numbers = "1234567890"
         lowercase = "abcdefghijklmnopqrstuvwxyz"
         uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        specialchars = "!#$&{*:[=,]-_%@+"
+        specialchars = "!#$&{*:[=,]-_%+"
 
         # Generates password string with:
         # lowercase,uppercase and numeric chars

--- a/tests/unittest/test_template_params.py
+++ b/tests/unittest/test_template_params.py
@@ -169,7 +169,7 @@ class TestParamGen(unittest.TestCase):
         genpassword_criteria = [
             # A tuple of (func_call, length, flags, re.Pattern, description)
             (pg.genpassword, 15, None, re.compile('[0-9A-Za-z]'), 'Testing a 15 character password. Default PW type'),
-            (pg.genpassword, 15, 'S', re.compile("[!#\$&{\*:\[=,\]-_%@\+a-zA-Z0-9]+"), 'Testing a 15 character password, Special Characters Type'),
+            (pg.genpassword, 15, 'S', re.compile("[!#\$&{\*:\[=,\]-_%\+a-zA-Z0-9]+"), 'Testing a 15 character password, Special Characters Type'),
             (pg.genpassword, 15, 'A', re.compile('[0-9A-Za-z]'), 'Testing a 15 character password, Alphanumeric Character Type')
         ]
         for func_call, pwlen, pwflags, re_pattern, test_desc in genpassword_criteria:


### PR DESCRIPTION
## Overview
Issue 335

This allows usage of `$[taskcat_genpass_8S]` random parameter for RDS password type in CloudFormation. By definition the RDS passwords can be:

> The password can include any printable ASCII character except "/", """, or "@".

## Testing/Steps taken to ensure quality
- Run the tests to verify that I didn't break existing tests or functionality
- Run the function 100 times to verify that it doesn't produce a password with `@`

It is a fairly trivial change.