### PR TITLE
Don't use the botocore vendored requests. Fixes #342

### DIFF
--- a/taskcat/generate_reports.py
+++ b/taskcat/generate_reports.py
@@ -1,7 +1,7 @@
 import time
 import yattag
 
-from botocore.vendored import requests
+import requests
 from taskcat.colored_console import PrintMsg
 from taskcat.common_utils import CommonTools
 from taskcat.exceptions import TaskCatException

--- a/taskcat/stacker.py
+++ b/taskcat/stacker.py
@@ -35,7 +35,7 @@ import logging
 import cfnlint.core
 import textwrap
 from argparse import RawTextHelpFormatter
-from botocore.vendored import requests
+import requests
 
 from pkg_resources import get_distribution
 


### PR DESCRIPTION
## Overview

Stop using the removed vendored `requests` lib from the `botocore` dep,

## Testing/Steps taken to ensure quality

Ran my existing CI suite using taskcat.

### Notes



## Testing Instructions

If a run generates a report without blowing up, this did its job.
