### PR TITLE
Exclude ap-east-1 and me-south-1 from AMI updates

### DIFF
--- a/taskcat/amiupdater.py
+++ b/taskcat/amiupdater.py
@@ -358,7 +358,8 @@ class AMIUpdater:
             'us-gov-west-1',
             'cn-northwest-1',
             'cn-north-1',
-            'ap-east-1'
+            'ap-east-1',
+            'me-south-1'
     ]
 
     def __init__(self, path_to_templates, user_config_file=None,

--- a/taskcat/amiupdater.py
+++ b/taskcat/amiupdater.py
@@ -357,7 +357,8 @@ class AMIUpdater:
             'us-gov-east-1',
             'us-gov-west-1',
             'cn-northwest-1',
-            'cn-north-1'
+            'cn-north-1',
+            'ap-east-1'
     ]
 
     def __init__(self, path_to_templates, user_config_file=None,


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed (use case)?

Getting errors in test run when AMI mapping contains ap-east-1 AMI IDs. Since we're unable to update AMI in ap-east-1 Region, we should skip it instead of breaking the builds

## Testing/Steps taken to ensure quality

Tested locally.

Error prior to change:

```
[taskcat-ci] Checking for outdated ami in "templates"
    Template: [templates/sas-viya.template.yaml] Region: [ap-east-1] is not a valid region
[taskcat-ci] AMI-UPDATER Exit code: 1
[taskcat-ci] fatal error ami checks! 
Build step 'Execute shell' marked build as failure
```

With the PR:

```$ bin/amiupdater  quickstart-sas-viya
[ERROR  ] : The ap-east-1 region is currently unsupported. AMI IDs will not be updated for this region.
[INFO   ] : Created all filters necessary for the API calls
[INFO   ] : Latest AMI IDs fetched
[INFO   ] : API results parsed
[INFO   ] : Templates updated as necessary
[INFO   ] : Complete!
```