### PR TITLE
[travis] Disabling cleanup on travis pypi deployment step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ jobs:
         fi
     deploy:
       - provider: pypi
+        skip_cleanup: true
         user: $PYPI_USER
         password: $PYPI_PASSWORD
 


### PR DESCRIPTION
The pypi deploy plugin in TravisCI appears to checkout the git repository again, with a clean stage environment. While the logic around development releases is working as intended, a duplicate 0.9.0 release is attempted;

~This PR swaps out the built-in travis-ci plugin for twine commands, and allows us more granular control of the build environment.~

This PR introduces the `skip_verify` option. If that doesn't work, another PR is forthcoming.
