### PR TITLE
More revisions to travis logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,13 +118,15 @@ jobs:
 
   - stage: "Tag next release & include changelog"
     name: "Tag next release & include changelog"
-    if: branch = master AND commit_message =~ /Merge.*from\ aws-quickstart\/[Rr]elease\/v.*$/ AND sender == taskcat-ci AND type = push
+    if: branch = master AND commit_message =~ /Merge\ pull\ request\ \#[0-9]{1,9}\ from\ aws-quickstart\/[Rr]elease\/v.*$/ AND type = push
     script:
       - |
         LAST_RELEASE_COMMIT=$(git rev-list --tags --max-count=1)
         TAG_BODY=$(git --no-pager log --no-merges --oneline ${LAST_RELEASE_COMMIT}..HEAD  --pretty='- %h %s')
         git tag -a "$(cat VERSION)" -m "${TAG_BODY}"
         git push --tags "https://$GHT:@github.com/$TRAVIS_REPO_SLUG"
+
+  - stage: Deploy release tag and documentation
     deploy:
       - provider: releases
         skip_cleanup: true


### PR DESCRIPTION
Looking at the travis API, the "sender" in travis-ci parlance is whomever _merged the pull request_, not who opened it. 

https://api.travis-ci.org/v3/build/607854388  - under _Created By_, at the bottom.

Editing the travis logic to reflect this discovery.

This PR also moves release-tagging and documentation to their own stage; 