### PR TITLE
Adding auto-generated docs for config object

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,9 +53,7 @@ If you are running Windows 10 we recommend that you install [Windows Subsystem f
 
 * Step 1: You will need to configure your boto profiles (taskcat will use you default profile if none is explictily provided)
 * Step 2: Create a taskcat test configurations
-
-example here:
-[taskcat.yml](https://raw.githubusercontent.com/taskcat/taskcat/master/tests/data/config_full_example/.taskcat.yml)
+    * [Config file schema](TASKCAT_CONFIG_FILE.md)
 
 ----
 **GitHub:**

--- a/docs/TASKCAT_CONFIG_FILE.md
+++ b/docs/TASKCAT_CONFIG_FILE.md
@@ -1,0 +1,38 @@
+* `general` _General configuration settings._
+    * `auth` _AWS authentication section_
+        * `<AUTH_NAME>` 
+    * `parameters` _Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence_
+        * `<PARAMETER_NAME>` 
+    * `s3_bucket` _Name of S3 bucket to upload project to, if left out a bucket will be auto-generated_
+    * `tags` _Tags to apply to CloudFormation template_
+        * `<TAG_NAME>` 
+* `project` _Project specific configuration section_
+    * `auth` _AWS authentication section_
+        * `<AUTH_NAME>` 
+    * `az_blacklist` _List of Availablilty Zones ID's to exclude when generating availability zones_
+    * `build_submodules` _Build Lambda zips recursively for submodules, set to false to disable_
+    * `lambda_source_path` _Path relative to the project root containing Lambda zip files, default is 'lambda_functions/source'_
+    * `lambda_zip_path` _Path relative to the project root to place Lambda zip files, default is 'lambda_functions/zips'_
+    * `name` _Project name, used as s3 key prefix when uploading objects_
+    * `owner` _email address for project owner (not used at present)_
+    * `package_lambda` _Package Lambda functions into zips before uploading to s3, set to false to disable_
+    * `parameters` _Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence_
+        * `<PARAMETER_NAME>` 
+    * `regions` _List of AWS regions_
+    * `s3_bucket` _Name of S3 bucket to upload project to, if left out a bucket will be auto-generated_
+    * `s3_enable_sig_v2` _Enable (deprecated) sigv2 access to auto-generated buckets_
+    * `s3_object_acl` _ACL for uploaded s3 objects, defaults to 'private'_
+    * `tags` _Tags to apply to CloudFormation template_
+        * `<TAG_NAME>` 
+    * `template` _path to template file relative to the project config file path_
+* `tests` 
+    * `auth` _AWS authentication section_
+        * `<AUTH_NAME>` 
+    * `az_blacklist` _List of Availablilty Zones ID's to exclude when generating availability zones_
+    * `parameters` _Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence_
+        * `<PARAMETER_NAME>` 
+    * `regions` _List of AWS regions_
+    * `s3_bucket` _Name of S3 bucket to upload project to, if left out a bucket will be auto-generated_
+    * `tags` _Tags to apply to CloudFormation template_
+        * `<TAG_NAME>` 
+    * `template` _path to template file relative to the project config file path_

--- a/docs/TASKCAT_CONFIG_FILE.md
+++ b/docs/TASKCAT_CONFIG_FILE.md
@@ -1,14 +1,14 @@
 * `general` _General configuration settings._
     * `auth` _AWS authentication section_
-        * `<AUTH_NAME>` 
+        * `<AUTH_NAME>`
     * `parameters` _Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence_
-        * `<PARAMETER_NAME>` 
+        * `<PARAMETER_NAME>`
     * `s3_bucket` _Name of S3 bucket to upload project to, if left out a bucket will be auto-generated_
     * `tags` _Tags to apply to CloudFormation template_
-        * `<TAG_NAME>` 
+        * `<TAG_NAME>`
 * `project` _Project specific configuration section_
     * `auth` _AWS authentication section_
-        * `<AUTH_NAME>` 
+        * `<AUTH_NAME>`
     * `az_blacklist` _List of Availablilty Zones ID's to exclude when generating availability zones_
     * `build_submodules` _Build Lambda zips recursively for submodules, set to false to disable_
     * `lambda_source_path` _Path relative to the project root containing Lambda zip files, default is 'lambda_functions/source'_
@@ -17,22 +17,22 @@
     * `owner` _email address for project owner (not used at present)_
     * `package_lambda` _Package Lambda functions into zips before uploading to s3, set to false to disable_
     * `parameters` _Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence_
-        * `<PARAMETER_NAME>` 
+        * `<PARAMETER_NAME>`
     * `regions` _List of AWS regions_
     * `s3_bucket` _Name of S3 bucket to upload project to, if left out a bucket will be auto-generated_
     * `s3_enable_sig_v2` _Enable (deprecated) sigv2 access to auto-generated buckets_
     * `s3_object_acl` _ACL for uploaded s3 objects, defaults to 'private'_
     * `tags` _Tags to apply to CloudFormation template_
-        * `<TAG_NAME>` 
+        * `<TAG_NAME>`
     * `template` _path to template file relative to the project config file path_
-* `tests` 
+* `tests`
     * `auth` _AWS authentication section_
-        * `<AUTH_NAME>` 
+        * `<AUTH_NAME>`
     * `az_blacklist` _List of Availablilty Zones ID's to exclude when generating availability zones_
     * `parameters` _Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence_
-        * `<PARAMETER_NAME>` 
+        * `<PARAMETER_NAME>`
     * `regions` _List of AWS regions_
     * `s3_bucket` _Name of S3 bucket to upload project to, if left out a bucket will be auto-generated_
     * `tags` _Tags to apply to CloudFormation template_
-        * `<TAG_NAME>` 
+        * `<TAG_NAME>`
     * `template` _path to template file relative to the project config file path_

--- a/generate_config_docs.py
+++ b/generate_config_docs.py
@@ -1,6 +1,10 @@
 # flake8: noqa
 import json
 
+SPACE_2 = "  "
+SPACE_4 = "    "
+SPACE_8 = "        "
+
 if __name__ == "__main__":
 
     schema = json.load(open("./taskcat/cfg/config_schema.json", "r"))
@@ -15,64 +19,56 @@ if __name__ == "__main__":
     for k, v in schema["properties"].items():
         item_str = f"* `{k}` "
         v = resolve_ref(v)
-        item_str += f"*type:* `{v['type']}` "
         if "description" in v:
-            item_str += f'{v["description"]}'
+            item_str += f'_{v["description"]}_'
         print(item_str)
         if "properties" in v:
             for ik, iv in v["properties"].items():
-                item_str = f"  * `{ik}` "
+                item_str = f"{SPACE_4}* `{ik}` "
                 iv = resolve_ref(iv)
-                item_str += f"*type:* `{iv['type']}` "
                 if "description" in iv:
-                    item_str += f'{iv["description"]}'
+                    item_str += f'_{iv["description"]}_'
                 print(item_str)
                 if iv["type"] == "object":
                     if "properties" in iv:
                         for iik, iiv in iv["properties"].items():
-                            item_str = f"  * `{iik}` "
+                            item_str = f"{SPACE_8}* `{iik}` "
                             iiv = resolve_ref(iiv)
-                            item_str += f"*type:* `{iiv['type']}` "
                             if "description" in iiv:
-                                item_str += f'{iiv["description"]}'
+                                item_str += f'_{iiv["description"]}_'
                     elif "additionalProperties" in iv:
                         name = ik[:-1] if ik.endswith("s") else ik
-                        item_str = f"    * `<{name.upper()}_NAME>` "
+                        item_str = f"{SPACE_8}* `<{name.upper()}_NAME>` "
                         props = resolve_ref(iv["additionalProperties"])
-                        item_str += f"*type:* `{iv['type']}` "
                         if "description" in props:
-                            item_str += f'{props["description"]}'
+                            item_str += f'_{props["description"]}_'
                     print(item_str)
         elif "additionalProperties" in v:
             name = k[:-1] if k.endswith("s") else k
-            item_str = f"  * `<{name.upper()}_NAME>` "
+            item_str = f" * `<{name.upper()}_NAME>` "
             props = resolve_ref(v["additionalProperties"])
-            item_str += f"*type:* `{v['type']}` "
             if "description" in props:
-                item_str += f'{props["description"]}'
+                item_str += f'_{props["description"]}_'
             if "properties" in props:
                 for ik, iv in props["properties"].items():
-                    item_str = f"  * `{ik}` "
+                    item_str = f"{SPACE_4}* `{ik}` "
                     iv = resolve_ref(iv)
-                    item_str += f"*type:* `{iv['type']}` "
                     if "description" in iv:
-                        item_str += f'{iv["description"]}'
+                        item_str += f'_{iv["description"]}_'
                     print(item_str)
                     if iv["type"] == "object":
                         if "properties" in iv:
                             for iik, iiv in iv["properties"].items():
-                                item_str = f"    * `{iik}` "
+                                item_str = f"{SPACE_8}* `{iik}` "
                                 iiv = resolve_ref(iiv)
-                                item_str += f"*type:* `{iiv['type']}` "
                                 if "description" in iiv:
-                                    item_str += f'{iiv["description"]}'
+                                    item_str += f'_{iiv["description"]}_'
                         elif "additionalProperties" in iv:
                             name = ik[:-1] if ik.endswith("s") else ik
-                            item_str = f"    * `<{name.upper()}_NAME>` "
+                            item_str = f"{SPACE_8}* `<{name.upper()}_NAME>` "
                             iprops = resolve_ref(iv["additionalProperties"])
-                            item_str += f"*type:* `{iv['type']}` "
                             if "description" in iprops:
-                                item_str += f'{iprops["description"]}'
+                                item_str += f'_{iprops["description"]}_'
                         print(item_str)
         else:
             print(v)


### PR DESCRIPTION
This PR Modifies the `generate_config_docs.py` script to reflect supported indentation levels in mkdocs. A link is also added to the `docs/README.md` file. 

A visual representation was tested using `mkdocs serve` locally