### PR TITLE
catch tests with missing required param values

### DIFF
--- a/tests/data/missing_param_values/.taskcat.yml
+++ b/tests/data/missing_param_values/.taskcat.yml
@@ -1,0 +1,8 @@
+project:
+  name: missing-required-param-values
+  regions:
+  - us-east-1
+  - us-west-2
+tests:
+  taskcat-json:
+    template: templates/test.template.yaml

--- a/tests/data/missing_param_values/templates/test.template.yaml
+++ b/tests/data/missing_param_values/templates/test.template.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ParamNotInConfig:
+    Type: String
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties: {}


### PR DESCRIPTION
## Overview

If a template contains required parameters (no default) and there are no supplied values, taskcat should fail gracefully with a meaningful error.

Not the prettiest fix, but will catch all missing params across tests, error on each and exit.
