### PR TITLE
Throwing an exception if a parameter value is None. Fixes #391

### DIFF
--- a/taskcat/_template_params.py
+++ b/taskcat/_template_params.py
@@ -35,6 +35,18 @@ class ParamGen:
     def __init__(self, param_dict, bucket_name, region, boto_client, az_excludes=None):
         self.regxfind = CommonTools.regxfind
         self._param_dict = param_dict
+        _missing_params = []
+        for param_name, param_value in param_dict.items():
+            if param_value is None:
+                _missing_params.append(param_name)
+        if _missing_params:
+            raise TaskCatException(
+                (
+                    f"The following parameters have no value whatsoever. "
+                    f"The CloudFormation stack will fail to launch. "
+                    f"Please address. str({_missing_params})"
+                )
+            )
         self.results = {}
         self.mutated_params = {}
         self.param_name = None

--- a/tests/test_template_params.py
+++ b/tests/test_template_params.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import re
 import unittest
@@ -374,6 +375,12 @@ class TestParamGen(unittest.TestCase):
             x for x in dir(ParamGen) if type(getattr(ParamGen, x)) == regex_type
         }
         self.assertEqual(all_expressions, tested_expressions)
+
+    def test_param_value_none_raises_exception(self):
+        params = copy.deepcopy(self.class_kwargs)
+        params["param_dict"] = {"Foo": None}
+        with self.assertRaises(TaskCatException):
+            _ = ParamGen(**params)
 
     def test_regex_replace_param_value(self):
         pg = ParamGen(**self.class_kwargs)


### PR DESCRIPTION
This PR accounts for a param value being None. This occurs if there's no Default value in the template, and no parameter value is passed in. A duplicate of #395 , but I think this handles it better.