### PR TITLE
add pip and raw lambda package methods

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ docker~=3.7
 dulwich~=0.19
 dataclasses;python_version<"3.7"
 dataclasses-jsonschema>=2.9.0,<3.0
+pip

--- a/taskcat/_lambda_build.py
+++ b/taskcat/_lambda_build.py
@@ -1,10 +1,14 @@
 import logging
+import shutil
+import tempfile
 from pathlib import Path
+from subprocess import CalledProcessError, run as subprocess_run  # nosec
 from uuid import UUID, uuid5
 
 import docker
 
 from ._config import Config
+from .exceptions import TaskCatException
 
 LOG = logging.getLogger(__name__)
 
@@ -48,12 +52,70 @@ class LambdaBuild:
         if not parent_path.is_dir():
             return
         for path in parent_path.iterdir():
-            if not (path / "Dockerfile").is_file():
-                continue
-            tag = f"taskcat-build-{uuid5(self.NULL_UUID, str(path)).hex}"
-            LOG.info(f"Packaging lambda source from {path} using docker image {tag}")
-            self._docker_build(path, tag)
-            self._docker_extract(tag, output_path / path.stem)
+            if (path / "Dockerfile").is_file():
+                tag = f"taskcat-build-{uuid5(self.NULL_UUID, str(path)).hex}"
+                LOG.info(
+                    f"Packaging lambda source from {path} using docker image {tag}"
+                )
+                self._docker_build(path, tag)
+                self._docker_extract(tag, output_path / path.stem)
+            elif (path / "requirements.txt").is_file():
+                LOG.info(f"Packaging python lambda source from {path} using pip")
+                self._pip_build(path, output_path / path.stem)
+            else:
+                LOG.info(
+                    f"Packaging lambda source from {path} without building "
+                    f"dependencies"
+                )
+                self._zip_dir(path, output_path / path.stem)
+
+    @staticmethod
+    def _make_pip_command(base_path):
+        return [
+            "pip",
+            "install",
+            "--no-cache-dir",
+            "--no-color",
+            "--disable-pip-version-check",
+            "--upgrade",
+            "--requirement",
+            str(base_path / "requirements.txt"),
+            "--target",
+            str(base_path),
+        ]
+
+    @classmethod
+    def _pip_build(cls, base_path, output_path):
+        tmp_path = Path(tempfile.mkdtemp())
+        try:
+            build_path = tmp_path / "build"
+            shutil.copytree(base_path, build_path)
+            command = cls._make_pip_command(build_path)
+            LOG.debug("command is '%s'", command)
+
+            LOG.info("Starting pip build.")
+            try:
+                completed_proc = subprocess_run(  # nosec
+                    command, capture_output=True, cwd=build_path, check=True
+                )
+            except (FileNotFoundError, CalledProcessError) as e:
+                shutil.rmtree(tmp_path, ignore_errors=True)
+                raise TaskCatException("pip build failed") from e
+            LOG.debug("--- pip stdout:\n%s", completed_proc.stdout)
+            LOG.debug("--- pip stderr:\n%s", completed_proc.stderr)
+            cls._zip_dir(build_path, output_path)
+            shutil.rmtree(tmp_path, ignore_errors=True)
+        except Exception as e:  # pylint: disable=broad-except
+            shutil.rmtree(tmp_path, ignore_errors=True)
+            raise e
+
+    @staticmethod
+    def _zip_dir(build_path, output_path):
+        output_path.mkdir(exist_ok=True)
+        zip_path = output_path / "lambda.zip"
+        if zip_path.is_file():
+            zip_path.unlink()
+        shutil.make_archive(output_path / "lambda", "zip", build_path)
 
     @staticmethod
     def _clean_build_log(line):

--- a/tests/data/lambda_build_with_submodules/functions/source/TestFuncPip/a_file
+++ b/tests/data/lambda_build_with_submodules/functions/source/TestFuncPip/a_file
@@ -1,0 +1,9 @@
+FROM lambci/lambda:build-python3.7
+
+COPY . .
+
+RUN pip install -t . -r ./requirements.txt && \
+    rm -rf *.dist-info *.pth && \
+    rm Dockerfile requirements.txt
+
+CMD zip -FS -r /output/lambda.zip ./

--- a/tests/data/lambda_build_with_submodules/functions/source/TestFuncPip/requirements.txt
+++ b/tests/data/lambda_build_with_submodules/functions/source/TestFuncPip/requirements.txt
@@ -1,0 +1,1 @@
+certifi

--- a/tests/data/lambda_build_with_submodules/functions/source/TestFuncRaw/a_file
+++ b/tests/data/lambda_build_with_submodules/functions/source/TestFuncRaw/a_file
@@ -1,0 +1,9 @@
+FROM lambci/lambda:build-python3.7
+
+COPY . .
+
+RUN pip install -t . -r ./requirements.txt && \
+    rm -rf *.dist-info *.pth && \
+    rm Dockerfile requirements.txt
+
+CMD zip -FS -r /output/lambda.zip ./


### PR DESCRIPTION
## Overview

previous behavior was to skip the build step if there was no Dockerfile present. This adds two additional cases:

* `requirements.txt` present, runs a `pip install` to build deps and packages a zip
* catchall zips the contents of the source folder as is
 