### PR TITLE
fix list output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,11 @@ repos:
   - id: isort
     # language_version: python3.6
 - repo: https://github.com/ambv/black
-  rev: 19.3b0
+  rev: 19.10b0
   hooks:
   - id: black
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v2.4.0
   hooks:
   - id: check-case-conflict
   - id: end-of-file-fixer
@@ -36,7 +36,7 @@ repos:
     - --no-sort-keys
   - id: check-merge-conflict
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.4.1
+  rev: v1.4.2
   hooks:
   - id: python-check-blanket-noqa
   - id: python-check-mock-methods
@@ -48,7 +48,7 @@ repos:
     files: "^taskcat/"
     args: ["--skip", "B322"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.730
+  rev: v0.740
   hooks:
   - id: mypy
     files: "^taskcat/"

--- a/taskcat/_cfn/template.py
+++ b/taskcat/_cfn/template.py
@@ -145,7 +145,7 @@ class Template:
         return list(desc_map.values())
 
     def parameters(
-        self
+        self,
     ) -> Dict[str, Union[None, str, int, bool, List[Union[int, str]]]]:
         parameters = {}
         for param_key, param in self.template.get("Parameters", {}).items():

--- a/taskcat/_cli_modules/list.py
+++ b/taskcat/_cli_modules/list.py
@@ -86,7 +86,7 @@ class List:
         if not jobs:
             LOG.info("no stacks found")
             return
-        if _stack_type == "test":
+        if _stack_type != "test":
             header = (
                 f"NAME{spaces(longest_name)}PROJECT{spaces(longest_project_name)}"
                 f"ID{spaces(34)}REGION"

--- a/taskcat/_common_utils.py
+++ b/taskcat/_common_utils.py
@@ -34,9 +34,8 @@ def name_from_stack_id(stack_id):
 
 def s3_url_maker(bucket, key, s3_client):
     location = s3_client.get_bucket_location(Bucket=bucket)["LocationConstraint"]
-    url = (
-        f"https://{bucket}.s3.amazonaws.com/{key}"
-    )  # default case for us-east-1 which returns no location
+    # default case for us-east-1 which returns no location
+    url = f"https://{bucket}.s3.amazonaws.com/{key}"
     if location:
         domain = get_s3_domain(location)
         url = f"https://{bucket}.s3-{location}.{domain}/{key}"

--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -308,7 +308,7 @@ class TestObj:
 
 
 @dataclass
-class GeneralConfig(JsonSchemaMixin, allow_additional_props=False):
+class GeneralConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ignore
     """General configuration settings."""
 
     parameters: Optional[Dict[ParameterKey, ParameterValue]] = field(
@@ -322,7 +322,7 @@ class GeneralConfig(JsonSchemaMixin, allow_additional_props=False):
 
 
 @dataclass
-class TestConfig(JsonSchemaMixin, allow_additional_props=False):
+class TestConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ignore
     """Test specific configuration section."""
 
     template: Optional[str] = field(default=None, metadata=METADATA["template"])
@@ -344,7 +344,7 @@ class TestConfig(JsonSchemaMixin, allow_additional_props=False):
 
 # pylint: disable=too-many-instance-attributes
 @dataclass
-class ProjectConfig(JsonSchemaMixin, allow_additional_props=False):
+class ProjectConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ignore
     """Project specific configuration section"""
 
     name: Optional[ProjectName] = field(
@@ -393,7 +393,7 @@ PROPOGATE_ITEMS = ["regions", "s3_bucket", "template", "az_blacklist"]
 # pylint raises false positive due to json-dataclass
 # pylint: disable=no-member
 @dataclass
-class BaseConfig(JsonSchemaMixin, allow_additional_props=False):
+class BaseConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ignore
     """Taskcat configuration file"""
 
     general: GeneralConfig = field(default_factory=GeneralConfig)

--- a/taskcat/_generate_reports.py
+++ b/taskcat/_generate_reports.py
@@ -25,7 +25,7 @@ class ReportBuilder:
 
     # TODO: refactor for readability
     def generate_report(  # noqa: C901
-        self
+        self,
     ):  # pylint: disable=too-many-locals, too-many-statements
         doc = yattag.Doc()
 

--- a/tests/test_cfn_lint.py
+++ b/tests/test_cfn_lint.py
@@ -200,8 +200,8 @@ class TestCfnLint(unittest.TestCase):
             self.assertEqual(mock_log_warning.called, False)
 
             mock_log_info.reset_mock()
-            lint_key = [t for t in lint.lints[0]][0]
-            result_key = [t for t in lint.lints[0][lint_key]["results"]][0]
+            lint_key = list(lint.lints[0])[0]
+            result_key = list(lint.lints[0][lint_key]["results"])[0]
             test = lint.lints[0][lint_key]["results"][result_key]
             rule = mock.Mock(return_val="[W0001] some warning")
             rule.rule.id = "W0001"
@@ -259,8 +259,8 @@ class TestCfnLint(unittest.TestCase):
             lint = Lint(config=config, templates=templates)
             self.assertEqual(lint.passed, True)
 
-            lint_key = [t for t in lint.lints[0]][0]
-            result_key = [t for t in lint.lints[0][lint_key]["results"]][0]
+            lint_key = list(lint.lints[0])[0]
+            result_key = list(lint.lints[0][lint_key]["results"])[0]
             test = lint.lints[0][lint_key]["results"][result_key]
             rule = mock.Mock(return_val="[E0001] some error")
             rule.rule.id = "E0001"


### PR DESCRIPTION
## Overview

`taskcat test list` was failing with `IndexError tuple index out of range` due to an inverted comparison

ran the following tests:

```bash
taskcat test run -n
taskcat test list
taskcat test clean ALL
###
taskcat deploy aws-vpc
taskcat list
taskcat delete <ID-FROM-LIST>
```