### PR TITLE
TemplateBody is sometimes a string

### DIFF
--- a/taskcat/_cfn/stack.py
+++ b/taskcat/_cfn/stack.py
@@ -332,10 +332,11 @@ class Stack:  # pylint: disable=too-many-instance-attributes
                     + ".template"
                 )
                 absolute_path = path / fname
-                template_str = ordered_dump(tempate_body, dumper=yaml.SafeDumper)
+                if not isinstance(tempate_body, str):
+                    tempate_body = ordered_dump(tempate_body, dumper=yaml.SafeDumper)
                 if not absolute_path.exists():
                     with open(absolute_path, "w") as fh:
-                        fh.write(template_str)
+                        fh.write(tempate_body)
             except Exception as e:  # pylint: disable=broad-except
                 LOG.warning(
                     f"Failed to attach child stack "

--- a/taskcat/_cfn/template.py
+++ b/taskcat/_cfn/template.py
@@ -72,7 +72,7 @@ class Template:
         template_path = self.project_root / template_path
         if template_path.is_file():
             return template_path
-        LOG.error(
+        LOG.warning(
             "Failed to discover path for %s, path %s does not exist",
             template_url,
             template_path,


### PR DESCRIPTION
## Overview

boto3 claims that `get_template` returns the template body, but in some (all?) cases it returns the template as a string.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.get_template

Fixes #423