### PR TITLE
retry if we're sure the bucket exists

### DIFF
--- a/taskcat/_cfn/stack.py
+++ b/taskcat/_cfn/stack.py
@@ -281,7 +281,10 @@ class Stack:  # pylint: disable=too-many-instance-attributes
             project_root=template.project_root,
             s3_key_prefix=template.s3_key_prefix,
             url=s3_url_maker(
-                region.s3_bucket.name, template.s3_key, region.client("s3")
+                region.s3_bucket.name,
+                template.s3_key,
+                region.client("s3"),
+                region.s3_bucket.auto_generated,
             ),
         )
         stack_id = cfn_client.create_stack(

--- a/taskcat/_common_utils.py
+++ b/taskcat/_common_utils.py
@@ -6,6 +6,7 @@ import re
 import string
 import sys
 from collections import OrderedDict
+from time import sleep
 
 import boto3
 import yaml
@@ -32,13 +33,24 @@ def name_from_stack_id(stack_id):
     return stack_id.split(":")[5].split("/")[1]
 
 
-def s3_url_maker(bucket, key, s3_client):
-    location = s3_client.get_bucket_location(Bucket=bucket)["LocationConstraint"]
+def s3_url_maker(bucket, key, s3_client, autobucket=False):
+    retries = 10
+    while True:
+        try:
+            response = s3_client.get_bucket_location(Bucket=bucket)
+            location = response["LocationConstraint"]
+            break
+        except s3_client.exceptions.NoSuchBucket:
+            if not autobucket or retries < 1:
+                raise
+            retries -= 1
+            sleep(5)
+
     # default case for us-east-1 which returns no location
-    url = f"https://{bucket}.s3.amazonaws.com/{key}"
+    url = f"https://{bucket}.s3.us-east-1.amazonaws.com/{key}"
     if location:
         domain = get_s3_domain(location)
-        url = f"https://{bucket}.s3-{location}.{domain}/{key}"
+        url = f"https://{bucket}.s3.{location}.{domain}/{key}"
     return url
 
 

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -40,12 +40,14 @@ class TestCommonUtils(unittest.TestCase):
         m_s3.get_bucket_location.return_value = {"LocationConstraint": None}
         actual = s3_url_maker("test-bucket", "test-key/1", m_s3)
 
-        self.assertEqual("https://test-bucket.s3.amazonaws.com/test-key/1", actual)
+        self.assertEqual(
+            "https://test-bucket.s3.us-east-1.amazonaws.com/test-key/1", actual
+        )
         m_s3.get_bucket_location.return_value = {"LocationConstraint": "us-west-2"}
 
         actual = s3_url_maker("test-bucket", "test-key/1", m_s3)
         self.assertEqual(
-            "https://test-bucket.s3-us-west-2.amazonaws.com/test-key/1", actual
+            "https://test-bucket.s3.us-west-2.amazonaws.com/test-key/1", actual
         )
         m_get_s3_domain.assert_called_once()
 


### PR DESCRIPTION
## Overview

intermittently buckets that taskcat has just created raise an exception if get_bucket_location is called right after the bucket has been created. This adds retries to give the bucket some time to propagate.

Also updates the s3 url format for `us-east-1` buckets to include the region in the hostname.