### PR TITLE
add caching to travis for pip/pre-commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ branches:
   only:
   - master
 
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
+    - $TRAVIS_BUILD_DIR/.mypy_cache
+
 python:
   - "3.6"
   - "3.7"


### PR DESCRIPTION
## Overview

adds caching for pre-commit deps, pip packages and mypy stubs in the hope of speeding up pr tests.