### PR TITLE
Refactoring S3 SigV2 CLI Argument in test subcommand

### DIFF
--- a/examples/sample-taskcat-project/templates/debug.template
+++ b/examples/sample-taskcat-project/templates/debug.template
@@ -199,7 +199,7 @@
                 },
                 "Handler": "index.handler",
                 "Runtime": "python2.7",
-                "Timeout": "5",
+                "Timeout": 5,
                 "Role": {
                     "Fn::GetAtt": [
                         "LambdaExecutionRole",

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -52,10 +52,17 @@ class Test:
         input_file_path: Path = project_root_path / input_file
         config = Config.create(
             project_root=project_root_path,
+            project_config_path=input_file_path
             # TODO: detect if input file is taskcat config or CloudFormation template
-            project_config_path=input_file_path,
-            args={"project": {"s3_enable_sig_v2": enable_sig_v2}},
         )
+
+        if enable_sig_v2:
+            config = Config.create(
+                project_root=project_root_path,
+                project_config_path=input_file_path,
+                args={"project": {"s3_enable_sig_v2": enable_sig_v2}},
+            )
+
         boto3_cache = Boto3Cache()
         templates = config.get_templates(project_root_path)
         # 1. lint

--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -23,6 +23,7 @@ OVERRIDES = Path("./.taskcat_overrides.yml").resolve()
 
 DEFAULTS = {
     "project": {
+        "s3_enable_sig_v2": False,
         "build_submodules": True,
         "package_lambda": True,
         "lambda_zip_path": "lambda_functions/packages",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,7 @@ class TestNewConfig(unittest.TestCase):
                 "build_submodules": False,
                 "template": "template1.yaml",
                 "s3_bucket": "set-in-global",
+                "s3_enable_sig_v2": False,
             },
             "tests": {
                 "default": {
@@ -78,6 +79,7 @@ class TestNewConfig(unittest.TestCase):
             },
             "project": {
                 "s3_bucket": str(base_path / ".taskcat_global.yml"),
+                "s3_enable_sig_v2": "TASKCAT_DEFAULT",
                 "package_lambda": "EnvoronmentVariable",
                 "lambda_zip_path": "TASKCAT_DEFAULT",
                 "lambda_source_path": "TASKCAT_DEFAULT",


### PR DESCRIPTION
## Overview

This PR slightly changes the logic in the test subcommand. Previously the `s3_enable_sig_v2` config option was being force-passed as a CLIArgument to a Config object. As CLI arguments are processed last in the Config class, setting `s3_enable_sig_v2: True` in either the global or project config file was ignored. 

## Testing/Steps taken to ensure quality

I've tested this using a debugger with the sample taskcat project in `examples/`. Unit tests and pre-commit checks have been run as well. 

### Notes

I think there's a better way to handle the logic introduced in the test CLI module, but the linters/checks in pre-commit were not happy at me.