### PR TITLE
Honoring tags within config file. Closes #449

### DIFF
--- a/taskcat/_cfn/stack.py
+++ b/taskcat/_cfn/stack.py
@@ -15,7 +15,7 @@ import yaml
 
 from taskcat._cfn.template import Template
 from taskcat._common_utils import ordered_dump, pascal_to_snake, s3_url_maker
-from taskcat._dataclasses import TestRegion
+from taskcat._dataclasses import Tag, TestRegion
 
 LOG = logging.getLogger(__name__)
 
@@ -153,18 +153,6 @@ class Output:
             self.description = output_dict["Description"]
         if "ExportName" in output_dict.keys():
             self.export_name = output_dict["ExportName"]
-
-
-class Tag:
-    def __init__(self, tag_dict: dict):
-        if isinstance(tag_dict, Tag):
-            tag_dict = {"Key": tag_dict.key, "Value": tag_dict.value}
-        self.key: str = tag_dict["Key"]
-        self.value: str = tag_dict["Value"]
-
-    def dump(self):
-        tag_dict = {"Key": self.key, "Value": self.value}
-        return tag_dict
 
 
 class FilterableList(list):

--- a/taskcat/_cfn/threaded.py
+++ b/taskcat/_cfn/threaded.py
@@ -6,10 +6,10 @@ from typing import Dict, List
 
 import boto3
 
-from taskcat._cfn.stack import Stack, Stacks, StackStatus, Tag
+from taskcat._cfn.stack import Stack, Stacks, StackStatus
 from taskcat._client_factory import Boto3Cache
 from taskcat._common_utils import merge_dicts
-from taskcat._dataclasses import TestObj, TestRegion
+from taskcat._dataclasses import Tag, TestObj, TestRegion
 from taskcat.exceptions import TaskCatException
 
 LOG = logging.getLogger(__name__)
@@ -67,6 +67,7 @@ class Stacker:
         )
         tags.append(Tag({"Key": "taskcat-project-name", "Value": self.project_name}))
         tags.append(Tag({"Key": "taskcat-test-name", "Value": test.name}))
+        tags += test.tags
         partial_kwargs = {
             "stack_name": stack_name,
             "template": test.template,

--- a/taskcat/_cli_modules/deploy.py
+++ b/taskcat/_cli_modules/deploy.py
@@ -6,10 +6,10 @@ from time import sleep
 
 from dulwich import porcelain
 from dulwich.config import ConfigFile, parse_submodules
-from taskcat._cfn.stack import Tag
 from taskcat._cfn.threaded import Stacker
 from taskcat._client_factory import Boto3Cache
 from taskcat._config import Config
+from taskcat._dataclasses import Tag
 from taskcat._name_generator import generate_name
 from taskcat._s3_stage import stage_in_s3
 from taskcat.exceptions import TaskCatException

--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -9,7 +9,14 @@ import yaml
 from taskcat._cfn.template import Template
 from taskcat._client_factory import Boto3Cache
 from taskcat._common_utils import generate_bucket_name
-from taskcat._dataclasses import BaseConfig, RegionObj, S3BucketObj, TestObj, TestRegion
+from taskcat._dataclasses import (
+    BaseConfig,
+    RegionObj,
+    S3BucketObj,
+    Tag,
+    TestObj,
+    TestRegion,
+)
 from taskcat._legacy_config import legacy_overrides, parse_legacy_config
 from taskcat._template_params import ParamGen
 from taskcat.exceptions import TaskCatException
@@ -317,6 +324,10 @@ class Config:
         tests = {}
         for test_name, test in self.config.tests.items():
             region_list = []
+            tag_list = []
+            if test.tags:
+                for tag_key, tag_value in test.tags.items():
+                    tag_list.append(Tag({"Key": tag_key, "Value": tag_value}))
             for region_obj in regions[test_name].values():
                 region_list.append(
                     TestRegion.from_region_obj(
@@ -331,5 +342,6 @@ class Config:
                 template=templates[test_name],
                 project_root=project_root,
                 regions=region_list,
+                tags=tag_list,
             )
         return tests

--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -288,6 +288,18 @@ class S3BucketObj:
         return False
 
 
+class Tag:
+    def __init__(self, tag_dict: dict):
+        if isinstance(tag_dict, Tag):
+            tag_dict = {"Key": tag_dict.key, "Value": tag_dict.value}
+        self.key: str = tag_dict["Key"]
+        self.value: str = tag_dict["Value"]
+
+    def dump(self):
+        tag_dict = {"Key": self.key, "Value": self.value}
+        return tag_dict
+
+
 @dataclass
 class TestRegion(RegionObj):
     s3_bucket: S3BucketObj
@@ -305,6 +317,7 @@ class TestObj:
     project_root: Path
     name: TestName
     regions: List[TestRegion]
+    tags: List[Tag]
 
 
 @dataclass

--- a/tests/test_cfn_stack.py
+++ b/tests/test_cfn_stack.py
@@ -14,11 +14,11 @@ from taskcat._cfn.stack import (
     Resource,
     Resources,
     Stack,
-    Tag,
     Tags,
     TestRegion,
     criteria_matches,
 )
+from taskcat._dataclasses import Tag
 
 event_template = {
     "EventId": "test_event_id",
@@ -41,7 +41,7 @@ class TestCriteriaMatcher(unittest.TestCase):
             tag = Tag({"Key": "my_key", "Value": "my_value"})
             criteria_matches({"invalid": "blah"}, tag)
         self.assertEqual(
-            "invalid is not a valid property of <class 'taskcat._cfn.stack.Tag'>",
+            "invalid is not a valid property of <class 'taskcat._dataclasses.Tag'>",
             str(cm.exception),
         )
 


### PR DESCRIPTION
This is a fix to #449, where it was reported that tags defined in the taskcat config file were not being honored.