### PR TITLE
Converting path to posix style to prevent error on windows

### DIFF
--- a/taskcat/_cfn/template.py
+++ b/taskcat/_cfn/template.py
@@ -37,7 +37,7 @@ class Template:
 
     @property
     def s3_key(self):
-        suffix = str(self.template_path.relative_to(self.project_root))
+        suffix = str(self.template_path.relative_to(self.project_root).as_posix())
         return self._s3_key_prefix + suffix
 
     @property


### PR DESCRIPTION
## Overview
I know that taskcat currently is not supported in Windows but I do use it on windows and only thing which currently stops me using it on windows is it creates wrong s3 URL for template after uploading it on s3 due to windows path format.
Eg. c:\user\project\template\my-template.yml when uploaded on s3, URL becomes https://s3.console.aws.amazon.com/s3/object/your-bucket-name/cf-project/templates\my-template.yml and hence give error that it is not correct s3 bucket URL.
In above example correct URL should be, https://s3.console.aws.amazon.com/s3/object/your-bucket-name/cf-project/templates\my-template.yml

## Testing/Steps taken to ensure quality
I have run above change in my windows machine as well on mac to make sure it works

