### PR TITLE
Supporting lists as a parameter value. Closes #443

### DIFF
--- a/taskcat/_template_params.py
+++ b/taskcat/_template_params.py
@@ -65,6 +65,25 @@ class ParamGen:
         # - $[taskcat_gets3contents]
         # - $[taskcat_geturl]
         for param_name, param_value in self._param_dict.items():
+            if isinstance(param_value, list):
+                _results_list = []
+                _nested_param_dict = {}
+                for idx, value in enumerate(param_value):
+                    _nested_param_dict[idx] = value
+                nested_pg = ParamGen(
+                    _nested_param_dict,
+                    self.bucket_name,
+                    self.region,
+                    self._boto_client,
+                    self.az_excludes,
+                )
+                nested_pg.transform_parameter()
+                for result_value in nested_pg.results.values():
+                    _results_list.append(result_value)
+                self.param_value = _results_list
+                self.results.update({param_name: _results_list})
+                continue
+
             # Setting the instance variables to reflect key/value pair we're working on.
             self.param_name = param_name
             self.param_value = param_value

--- a/tests/test_template_params.py
+++ b/tests/test_template_params.py
@@ -449,3 +449,25 @@ class TestParamGen(unittest.TestCase):
             for _param_key, param_value in pg.results.items():
                 if _param_key == "SingleAZ":
                     self.assertEqual(param_value, "us-east-1b")
+
+    def test_list_as_param_value(self):
+        input_params = {
+            "ExampleList": [
+                "$[taskcat_getsingleaz_1]",
+                "$[taskcat_getsingleaz_2]",
+                "foobar",
+            ],
+            "ExampleString": "$[taskcat_getsingleaz_1]",
+        }
+        bclient = MockClient
+        bclient.logger = logger
+        class_kwargs = self.class_kwargs
+        class_kwargs["param_dict"] = input_params
+        class_kwargs["boto_client"] = bclient
+        pg = ParamGen(**class_kwargs)
+        pg.transform_parameter()
+        expected_result = {
+            "ExampleList": ["us-east-1a", "us-east-1b", "foobar"],
+            "ExampleString": "us-east-1a",
+        }
+        self.assertEqual(pg.results, expected_result)


### PR DESCRIPTION
This PR adds support for a list as a parameter value. Tests are included. 