### PR TITLE
Honoring default profile value. Closes #434

### DIFF
--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -221,7 +221,11 @@ class Config:
         for test_name, test in self.config.tests.items():
             region_objects[test_name] = {}
             for region in test.regions:
-                profile = test.auth.get(region, "default") if test.auth else "default"
+                profile = (
+                    test.auth.get(region, test.auth.get("default", "default"))
+                    if test.auth
+                    else "default"
+                )
                 region_objects[test_name][region] = RegionObj(
                     name=region,
                     account_id=boto3_cache.account_id(profile),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,10 +185,14 @@ class TestNewConfig(unittest.TestCase):
                         self.assertEqual(region_name, region_obj.name)
                         if test_name == "json-test" and region_name == "eu-central-1":
                             self.assertEqual("special-use-case", region_obj.profile)
+                        elif test_name == "yaml-test" and region_name == "sa-east-1":
+                            self.assertEqual("default", region_obj.profile)
                         elif region_name == "me-south-1":
                             self.assertEqual("mes1", region_obj.profile)
                         elif region_name == "ap-east-1":
                             self.assertEqual("hongkong", region_obj.profile)
+                        elif test_name == "yaml-test":
+                            self.assertEqual("foobar", region_obj.profile)
                         else:
                             self.assertEqual("default", region_obj.profile)
 


### PR DESCRIPTION
As reported in #434, taskcat was not honoring values set via...

```
auth:
  default: foobar
```

The intention of the original code was to honor the regional-based profile settings first, then the default profile settings, then set 'default' if necessary. Instead, we checked for regional profile settings, then skipped directly to 'default'. 

Tests are included, and passing. 