### PR TITLE
update pyyaml and docker deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ setuptools>=40.4.3
 boto3>=1.9.21,<2.0
 botocore>=1.12.21,<2.0
 yattag>=1.10.0,<2.0
-PyYAML>=4.2b1,<5.0
+PyYAML~=5.1
 jinja2>=2.10.0,<3.0
 requests>2.17.0
 jsonschema~=3.0
-docker~=3.7
+docker~=4.0
 dulwich~=0.19
 dataclasses;python_version<"3.7"
 dataclasses-jsonschema>=2.9.0,<3.0


### PR DESCRIPTION
## Overview

These two dependencies are shared by aws-sam-cli, which is commonly installed in the same virtualenv as taskcat (testing sam templates), so should not have conflicting version requirements.
