### PR TITLE
Add shorten_stack_name project parameter

### DIFF
--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -83,7 +83,11 @@ class Test:
         tests = config.get_tests(
             project_root_path, templates, regions, buckets, parameters
         )
-        test_definition = Stacker(config.config.project.name, tests)
+        test_definition = Stacker(
+            config.config.project.name,
+            tests,
+            shorten_stack_name=config.config.project.shorten_stack_name,
+        )
         test_definition.create_stacks()
         terminal_printer = TerminalPrinter()
         # 5. wait for completion

--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -35,6 +35,7 @@ DEFAULTS = {
         "package_lambda": True,
         "lambda_zip_path": "lambda_functions/packages",
         "lambda_source_path": "lambda_functions/source",
+        "shorten_stack_name": False,
     }
 }
 

--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -65,6 +65,9 @@ METADATA = {
     "s3_object_acl": {
         "description": "ACL for uploaded s3 objects, defaults to 'private'"
     },
+    "shorten_stack_name": {
+        "description": "Shorten stack names generated for tests, set to true to enable"
+    },
 }
 
 # types
@@ -396,6 +399,9 @@ class ProjectConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ign
     )
     s3_object_acl: Optional[str] = field(
         default=None, metadata=METADATA["s3_object_acl"]
+    )
+    shorten_stack_name: Optional[bool] = field(
+        default=None, metadata=METADATA["shorten_stack_name"]
     )
 
 

--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -154,6 +154,10 @@
                     "description": "ACL for uploaded s3 objects, defaults to 'private'",
                     "type": "string"
                 },
+                "shorten_stack_name": {
+                    "description": "Shorten stack names generated for tests, set to true to enable",
+                    "type": "boolean"
+                },
                 "tags": {
                     "additionalProperties": {
                         "type": "string"
@@ -275,6 +279,7 @@
                 "s3_bucket": null,
                 "s3_enable_sig_v2": null,
                 "s3_object_acl": null,
+                "shorten_stack_name": null,
                 "tags": null,
                 "template": null
             }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,7 @@ class TestNewConfig(unittest.TestCase):
                 "template": "template1.yaml",
                 "s3_bucket": "set-in-global",
                 "s3_enable_sig_v2": False,
+                "shorten_stack_name": False,
             },
             "tests": {
                 "default": {
@@ -80,6 +81,7 @@ class TestNewConfig(unittest.TestCase):
             "project": {
                 "s3_bucket": str(base_path / ".taskcat_global.yml"),
                 "s3_enable_sig_v2": "TASKCAT_DEFAULT",
+                "shorten_stack_name": "TASKCAT_DEFAULT",
                 "package_lambda": "EnvoronmentVariable",
                 "lambda_zip_path": "TASKCAT_DEFAULT",
                 "lambda_source_path": "TASKCAT_DEFAULT",


### PR DESCRIPTION
## Overview

Solves #360. Important for projects where the stack names cannot be too
long because some AWS services will use the stack name as a default
resource name prefix and this might be too long when using nested stacks.
## Testing/Steps taken to ensure quality

No tests added.

### Notes

Default behavior is the same as before.

## Testing Instructions

Add `shorten_stack_name: true` to the `taskcat.yaml` file and see that the stack name is going to be like: `tCat-testName-abc123`