### PR TITLE
Adding import_session to Boto3Cache; plus tests.

### DIFF
--- a/taskcat/_client_factory.py
+++ b/taskcat/_client_factory.py
@@ -31,6 +31,19 @@ class Boto3Cache:
         self._account_info: Dict[str, Dict[str, str]] = {}
         self._lock_cache_update = False
 
+    def import_session(self, session_suffix, session: boto3.Session, region: str):
+        """
+        Under edge cases, it may be necessary to import a pre-defined session
+        into the cache. Imported sessions will be cached with the prefix
+        'imported_session_', and can be used with that prefix.
+        ex:
+            <boto3Cache_instance>.import_session('us-east-1', session)
+           ec2 =  <boto3Cache_Instance>.get('ec2', profile='imported_session_us-east-1')
+        """
+        self._cache_set(
+            self._session_cache, [f"imported_session_{session_suffix}", region], session
+        )
+
     def session(self, profile: str = "default", region: str = None) -> boto3.Session:
         region = self._get_region(region, profile)
         try:

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -33,6 +33,14 @@ class TestBoto3Cache(unittest.TestCase):
     @mock.patch("taskcat._client_factory.Boto3Cache._cache_set", autospec=True)
     @mock.patch("taskcat._client_factory.Boto3Cache._cache_lookup", autospec=True)
     @mock.patch("taskcat._client_factory.boto3.Session", autospec=True)
+    def test_imported_session(self, mock_boto3, mock_cache_lookup, mock_cache_set):
+        x = Boto3Cache()
+        x.import_session("foobar", mock_boto3, "us-east-1")
+        self.assertEqual(mock_cache_set.called, True)
+
+    @mock.patch("taskcat._client_factory.Boto3Cache._cache_set", autospec=True)
+    @mock.patch("taskcat._client_factory.Boto3Cache._cache_lookup", autospec=True)
+    @mock.patch("taskcat._client_factory.boto3.Session", autospec=True)
     def test_session_no_profile(self, mock_boto3, mock_cache_lookup, mock_cache_set):
         mock_cache_lookup.side_effect = ProfileNotFound(profile="non-existent-profile")
         Boto3Cache().session()  # default value should be "default" profile

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -36,7 +36,9 @@ class TestBoto3Cache(unittest.TestCase):
     def test_imported_session(self, mock_boto3, mock_cache_lookup, mock_cache_set):
         x = Boto3Cache()
         x.import_session("foobar", mock_boto3, "us-east-1")
-        self.assertEqual(mock_cache_set.called, True)
+        mock_cache_set.assert_called_with(
+            x, x._session_cache, ["imported_session_foobar", "us-east-1"], mock_boto3
+        )
 
     @mock.patch("taskcat._client_factory.Boto3Cache._cache_set", autospec=True)
     @mock.patch("taskcat._client_factory.Boto3Cache._cache_lookup", autospec=True)


### PR DESCRIPTION
## Overview

This PR adds `import_session` to Boto3Cache, storing the session as a profile within the cache with a special prefix (imported_session). The prefix is added so that there's no namespace collisions between `imported_session_default` and `default`. 

If users want a standard profile (`default`, `us-east-1`, etc), they'll need to leverage the existing profile methods as previously documented.  

The intention here is to allow flexibility when importing the class in from-scratch modules (outside of taskcat).

## Context
The current cache only supports profiles. That works great for taskcat itself, and we've previously made design decisions to this effect.

However, it excludes in-memory credentials, such as those fetched from SecretStore, or via STS.AssumeRole. Without the ability to import an already-instantiated session, external modules are forced to write creds to disk. From there, boto3/botocore will pick them up as normal. Not ideal. 

## Testing/Steps taken to ensure quality

How did you validate the changes in this PR?

Unit tests - added.