### PR TITLE
Opt-in regional S3 buckets.

### DIFF
--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -23,6 +23,13 @@ from .list import List
 LOG = logging.getLogger(__name__)
 
 
+def _bucket_delete_evaluation(value, true_func, false_func):
+    if value:
+        true_func()
+    else:
+        false_func()
+
+
 class Test:
     """
     Performs functional tests on CloudFormation templates.
@@ -118,7 +125,11 @@ class Test:
             for test in buckets.values():
                 for bucket in test.values():
                     if bucket.name not in deleted:
-                        bucket.delete(delete_objects=True)
+                        _bucket_delete_evaluation(
+                            config.config.project.s3_regional_buckets,
+                            bucket.empty,
+                            bucket.delete,
+                        )
                         deleted.append(bucket.name)
         # 9. raise if something failed
         if len(status["FAILED"]) > 0:

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -23,13 +23,6 @@ from .list import List
 LOG = logging.getLogger(__name__)
 
 
-def _bucket_delete_evaluation(value, true_func, false_func):
-    if value:
-        true_func()
-    else:
-        false_func()
-
-
 class Test:
     """
     Performs functional tests on CloudFormation templates.
@@ -120,16 +113,13 @@ class Test:
         # TODO: summarise stack statusses (did they complete/delete ok) and print any
         #  error events
         # 8. delete buckets
+
         if not no_delete or (keep_failed is True and len(status["FAILED"]) == 0):
             deleted: ListType[str] = []
             for test in buckets.values():
                 for bucket in test.values():
-                    if bucket.name not in deleted:
-                        _bucket_delete_evaluation(
-                            config.config.project.s3_regional_buckets,
-                            bucket.empty,
-                            bucket.delete,
-                        )
+                    if (bucket.name not in deleted) and not bucket.regional_buckets:
+                        bucket.delete(delete_objects=True)
                         deleted.append(bucket.name)
         # 9. raise if something failed
         if len(status["FAILED"]) > 0:

--- a/taskcat/_common_utils.py
+++ b/taskcat/_common_utils.py
@@ -1,9 +1,7 @@
 import collections
 import logging
 import os
-import random
 import re
-import string
 import sys
 from collections import OrderedDict
 from functools import reduce
@@ -140,17 +138,6 @@ def merge_dicts(list_of_dicts):
 def pascal_to_snake(pascal):
     sub = ALL_CAP_RE.sub(r"\1_\2", pascal)
     return ALL_CAP_RE.sub(r"\1_\2", sub).lower()
-
-
-def generate_bucket_name(project: str, prefix: str = "tcat"):
-    if len(prefix) > 8 or len(prefix) < 1:  # pylint: disable=len-as-condition
-        raise TaskCatException("prefix must be between 1 and 8 characters long")
-    alnum = string.ascii_lowercase + string.digits
-    suffix = "".join(random.choice(alnum) for i in range(8))  # nosec: B311
-    mid = f"-{project}-"
-    avail_len = 63 - len(mid)
-    mid = mid[:avail_len]
-    return f"{prefix}{mid}{suffix}"
 
 
 def merge_nested_dict(old, new):

--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -47,6 +47,10 @@
                     "description": "Name of S3 bucket to upload project to, if left out a bucket will be auto-generated",
                     "type": "string"
                 },
+                "s3_regional_buckets": {
+                    "description": "Enable regional auto-buckets.",
+                    "type": "boolean"
+                },
                 "tags": {
                     "additionalProperties": {
                         "type": "string"
@@ -155,6 +159,10 @@
                     "pattern": "^(bucket-owner-full-control|bucket-owner-read|authenticated-read|aws-exec-read|public-read-write|public-read|private)$",
                     "type": "string"
                 },
+                "s3_regional_buckets": {
+                    "description": "Enable regional auto-buckets.",
+                    "type": "boolean"
+                },
                 "shorten_stack_name": {
                     "description": "Shorten stack names generated for tests, set to true to enable",
                     "type": "boolean"
@@ -238,6 +246,10 @@
                     "pattern": "^[a-z0-9-]*$",
                     "type": "string"
                 },
+                "s3_regional_buckets": {
+                    "description": "Enable regional auto-buckets.",
+                    "type": "boolean"
+                },
                 "tags": {
                     "additionalProperties": {
                         "type": "string"
@@ -261,6 +273,7 @@
                 "auth": null,
                 "parameters": null,
                 "s3_bucket": null,
+                "s3_regional_buckets": null,
                 "tags": null
             }
         },
@@ -280,6 +293,7 @@
                 "s3_bucket": null,
                 "s3_enable_sig_v2": null,
                 "s3_object_acl": null,
+                "s3_regional_buckets": null,
                 "shorten_stack_name": null,
                 "tags": null,
                 "template": null

--- a/tests/data/config_inheritance/.taskcat_global.yml
+++ b/tests/data/config_inheritance/.taskcat_global.yml
@@ -1,5 +1,6 @@
 general:
   s3_bucket: "set-in-global"
+  s3_regional_buckets: False
   parameters:
     GlobalVar: set_in_global
     OverridenVar: set_in_global

--- a/tests/data/regional_client_and_bucket/.taskcat_global_regional_bucket.yml
+++ b/tests/data/regional_client_and_bucket/.taskcat_global_regional_bucket.yml
@@ -1,0 +1,4 @@
+general:
+  s3_regional_buckets: True
+  parameters:
+    GlobalOverrideTest: success

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -261,7 +261,8 @@ class TestNewConfig(unittest.TestCase):
                     self.assertTrue(bucket_obj.sigv4, True)
                     self.assertEqual(bucket_obj.partition, "aws")
                     self.assertEqual(
-                        bucket_obj.name, f"tcat-66c782e8f95b-{region_name}"
+                        bucket_obj.name,
+                        f"tcat-13725204b43e5bf5a37800c23614ee21-{region_name}",
                     )
 
     @mock.patch("taskcat._config.Boto3Cache.account_id", return_value="123412341234")


### PR DESCRIPTION
_Continuation of #456. This is being reopened to resolve a coverage issue_

Part of the SigV2 -> SigV4 saga. This is necessary to facilitate SigV4 regional buckets. Initially, it'll create *more* buckets per test (1 per region), but those buckets will be retained (emptied if necessary). 

New buckets will be auto-created in this format:
`taskcat-<account_id_hash>-<region_name>`.

_Note: No modifications to `$[taskcat_autobucket]` are necessary due to the current design_

Special things to consider:
- This is opt-in via `s3_regional_buckets` from global down to test-level.
- Please pay special attention to these functions:

Dataclasses:
   - generate_bucket_name,
    - generate_regional_bucket_name,

Config:
  - _create_regional_bucket_obj
  - _create_legacy_bucket_obj


