### PR TITLE
[ClientFactory] Accounting for imported sesssions in get_default_region

### DIFF
--- a/taskcat/_client_factory.py
+++ b/taskcat/_client_factory.py
@@ -196,6 +196,9 @@ class Boto3Cache:
         raise ValueError("cannot find suitable AWS partition")
 
     def get_default_region(self, profile_name="default") -> str:
+        if profile_name.startswith("imported_session_"):
+            _, region = self._get_partition(profile_name)
+            return region
         try:
             region = self._boto3.session.Session(profile_name=profile_name).region_name
         except ProfileNotFound:


### PR DESCRIPTION
This was overlooked in the previous commit w/r/t imported sessions. This change returns the correct default region when Boto3Cache.client (and others) are called with an `imported_session_*` profile. 

Unit tests. Manual testing. Ran through E2E. 