### PR TITLE
Remove region from url when computing url prefix

### DIFF
--- a/taskcat/_cfn/template.py
+++ b/taskcat/_cfn/template.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 from typing import Dict, List, Union
 
@@ -89,9 +90,12 @@ class Template:
     def url_prefix(self) -> str:
         if not self.url:
             return ""
+        regionless_url = re.sub(
+            r"\.s3\.(.*)\.amazonaws\.com", ".s3.amazonaws.com", self.url,
+        )
         suffix = str(self.template_path).replace(str(self.project_root), "")
         suffix_length = len(suffix.lstrip("/").split("/"))
-        url_prefix = "/".join(self.url.split("/")[0:-suffix_length])
+        url_prefix = "/".join(regionless_url.split("/")[0:-suffix_length])
         return url_prefix
 
     def _find_children(self) -> None:  # noqa: C901


### PR DESCRIPTION
## Overview

This PR fixes the `url_prefix` to remove the region from the URL when it's available, because a main use-case of this property is to prefix match against child stacks gathered from update events, where they arrive without the region in their URLs.

## Testing/Steps taken to ensure quality

No tests added.

### Notes

Solves #487 

## Testing Instructions

Testing the fix requires using doubly nested stacks to reproduce #487. Stacks that don't have nesting shouldn't see different behavior.