### PR TITLE
Increase nesting restrictions on StackUrlHelper from 6 to 20

### DIFF
--- a/taskcat/_cfn/stack_url_helper.py
+++ b/taskcat/_cfn/stack_url_helper.py
@@ -24,7 +24,7 @@ LOG = logging.getLogger(__name__)
 
 
 class StackURLHelper:
-    MAX_DEPTH = 6  # Handle at most 6 levels of nesting in TemplateURL expressions
+    MAX_DEPTH = 20  # Handle at most 20 levels of nesting in TemplateURL expressions
     # TODO: Allow user to inject this
     # SUBSTITUTION = {
     #     "QSS3BucketName": "aws-quickstart",

--- a/tests/test_stack_url_helper.py
+++ b/tests/test_stack_url_helper.py
@@ -81,7 +81,7 @@ class TestStackURLHelper(unittest.TestCase):
         helper = StackURLHelper()
         with self.assertRaises(Exception) as context:
             helper.flatten_template_url(
-                "{ one { two } { two { three { four { five { six { seven }}}}} }}"
+                "{1{2{3{4{5{6{7{8{9{{{{{{{{{{{{21}}}}}}}}}}}}}}}}}}}}}"
             )
 
         self.assertTrue("Template URL contains more than" in str(context.exception))


### PR DESCRIPTION
## Overview

This is a fix for #514. It increases the recursive nesting limit to 20.

## Testing/Steps taken to ensure quality

Ran new unit tests.
Ran end to end tests.

### Notes

n/a

