### PR TITLE
Adding $[taskcat_current_region] magic parameter.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Do not add any additional owners to this file, this is being used to ensure that
 # functional tests are run before merge, the taskcat-ci bot will auto-approve once
 # tests have passed
-*       @taskcat-ci @jaymccon @andrew-glenn @avattathil
+*       @taskcat-ci @jaymccon @andrew-glenn @tonynv

--- a/taskcat/_template_params.py
+++ b/taskcat/_template_params.py
@@ -31,6 +31,7 @@ class ParamGen:
         r"\$\[\w+_presignedurl],(.*?,){1,2}.*?$", re.IGNORECASE
     )
     RE_GETVAL = re.compile(r"(?<=._getval_)(\w+)(?=]$)", re.IGNORECASE)
+    RE_CURRENT_REGION = re.compile(r"\$\[taskcat_current_region]", re.IGNORECASE)
 
     def __init__(self, param_dict, bucket_name, region, boto_client, az_excludes=None):
         self.regxfind = CommonTools.regxfind
@@ -131,6 +132,11 @@ class ParamGen:
 
             # $[taskcat_genuuid]
             self._regex_replace_param_value(self.RE_GENUUID, self._gen_uuid())
+
+            # $[taskcat_current_region]
+            self._regex_replace_param_value(
+                self.RE_CURRENT_REGION, self._gen_current_region()
+            )
             self.results.update({self.param_name: self.param_value})
 
     def get_available_azs(self, count):
@@ -280,6 +286,9 @@ class ParamGen:
 
     def _gen_autobucket(self):
         return self.bucket_name
+
+    def _gen_current_region(self):
+        return self.region
 
     def _gen_password_wrapper(self, gen_regex, type_regex, count_regex):
         if gen_regex.search(self.param_value):


### PR DESCRIPTION
## Overview

This PR adds the `$[taskcat_current_region]` magic parameter. It returns the region passed into the ParamGenerator class. 

Brief description of what this PR does, and why it is needed (use case)?

## Testing/Steps taken to ensure quality

Unit tests. Live tests.


```
BucketRegion | us-east-2
-- | --
```