### PR TITLE
only look for legacy config if new style one is not found

### DIFF
--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -129,7 +129,7 @@ class Config:
                 "source": str(project_config_path),
                 "config": base_cls._dict_from_file(project_config_path, fail_ok=False),
             }
-        except Exception as e:  # pylint: disable=broad-except
+        except FileNotFoundError as e:
             error = e
             try:
                 legacy_conf = parse_legacy_config(project_root)


### PR DESCRIPTION
With the blanket exception catching a project with an invalid new-style config and a valid legacy config would end up running the legacy config.

Legacy config should only be looked for if the new-style does not exist.