### PR TITLE
only package if config allows

### DIFF
--- a/taskcat/_cli_modules/package.py
+++ b/taskcat/_cli_modules/package.py
@@ -37,4 +37,7 @@ class Package:
                 }
             },
         )
+        if not config.config.project.package_lambda:
+            LOG.info("Lambda packaging disabled by config")
+            return
         LambdaBuild(config, project_root_path)


### PR DESCRIPTION
## Overview

The package command should not do anything if the project has explicitly disabled packaging in config with `package_lambda: false`.