### PR TITLE
Supporting multiple partitions in S3 SigV4 bucket policy. Closes #533

### DIFF
--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -212,7 +212,7 @@ class S3BucketObj:
                     "Effect": "Deny",
                     "Principal": "*",
                     "Action": "s3:*",
-                    "Resource": f"arn:aws:s3:::{self.name}/*",
+                    "Resource": f"arn:{self.partition}:s3:::{self.name}/*",
                     "Condition": {"StringEquals": {"s3:signatureversion": "AWS"}},
                 }
             ],


### PR DESCRIPTION
## Overview
Leverages `self.partition` to provide appropriate partition information to the SigV4 bucket policy. 
Previous was hard-coded to `arn:aws:<snip>`.


## Testing/Steps taken to ensure quality

- unit tests
- realtime tests (launched a test in aws-us-gov)