### PR TITLE
add test retry command to re-stage and re-launch an inner stack

### DIFF
--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List as ListType
 
 import boto3
+import yaml
 
 from taskcat._cfn._log_stack_events import _CfnLogTools
 from taskcat._cfn.threaded import Stacker
@@ -27,6 +28,48 @@ class Test:
     """
     Performs functional tests on CloudFormation templates.
     """
+
+    @staticmethod
+    def retry(region: str, stack_name: str, resource_name: str, config_file: str = "./.taskcat.yml",
+        project_root: str = "./"):
+        """[ALPHA] re-launches a child stack using the same parameters as previous launch
+
+        :param region: region stack is in
+        :param stack_name: name of parent stack
+        :param resource_name: logical id of child stack that will be re-launched
+        :param config_file: path to either a taskat project config file or a
+        CloudFormation template
+        :param project_root_path: root path of the project relative to input_file
+        """
+        LOG.warning("test retry is in alpha feature, use with caution")
+        project_root_path: Path = Path(project_root).expanduser().resolve()
+        input_file_path: Path = project_root_path / config_file
+        config = Config.create(
+            project_root=project_root_path,
+            project_config_path=input_file_path
+        )
+        profile = config.config.general.auth.get(region, config.config.general.auth.get("default", "default"))
+        cfn = boto3.Session(profile_name=profile).client("cloudformation", region_name=region)
+        events = cfn.describe_stack_events(StackName=stack_name)["StackEvents"]
+        resource = [i for i in events if i['LogicalResourceId'] == resource_name][0]
+        properties = yaml.safe_load(resource['ResourceProperties'])
+
+        with open(".taskcat.yml", "r") as fp:
+            config = yaml.safe_load(fp)
+
+        config["project"]["regions"] = [region]
+        config["project"]["parameters"] = properties["Parameters"]
+        config["project"]["template"] = "/".join(properties['TemplateURL'].split("/")[4:])
+        config["tests"] = {"default": {}}
+
+        with open("/tmp/.taskcat.yml.temp", "w") as fp:
+            yaml.safe_dump(config, fp)
+
+        cfn.delete_stack(StackName=resource['PhysicalResourceId'])
+        LOG.info("waiting for old stack to delete...")
+        cfn.get_waiter("stack_delete_complete").wait(StackName=resource['PhysicalResourceId'])
+
+        Test.run(input_file="/tmp/.taskcat.yml.temp", project_root=project_root, lint_disable=True)
 
     # pylint: disable=too-many-locals
     @staticmethod  # noqa: C901


### PR DESCRIPTION
## Overview

this pr introduces a `test retry` command.

When working on projects with nested templates and long launch time it costs a lot of time to-re-launch tests when an inner stack fails, because all of the successful resources that preceded the failed stack need to be needlessly re-launched.

Example usage:
```bash
cd quickstart-linux-bastion

# Run a test (note that -n is required here)
taskcat test run -n

# Let's say our test in eu-north-1 failed on the child stack BastionStack, you can now edit your project files and run:
taskcat test retry eu-north-1 tCaT-quickstart-linux-bastion-amznlinux2hvm-xxx BastionStack
```
this will get the parameters fed to the Bastion stack in the failed launch, delete BastionStack child stack, before uploading your updated project and re-launching the child stack with the same parameters. So the VPC does not need to be torn down and rebuilt to test your changes.

## Testing/Steps taken to ensure quality

ran it against the linux-bastion and eks quick starts.
