### PR TITLE
Moving project_root as an attribute to config object; plus tests throughout. Closes #540

### DIFF
--- a/taskcat/_cli_modules/deploy.py
+++ b/taskcat/_cli_modules/deploy.py
@@ -92,7 +92,7 @@ class Deploy:
         buckets = config.get_buckets(boto3_cache)
         stage_in_s3(buckets, config.config.project.name, path)
         regions = config.get_regions(boto3_cache)
-        templates = config.get_templates(project_root=path)
+        templates = config.get_templates()
         parameters = config.get_rendered_parameters(buckets, regions, templates)
         tests = config.get_tests(path, templates, regions, buckets, parameters)
         tags = [Tag({"Key": "taskcat-installer", "Value": name})]

--- a/taskcat/_cli_modules/lint.py
+++ b/taskcat/_cli_modules/lint.py
@@ -29,7 +29,7 @@ class Lint:
             project_root=project_root_path, project_config_path=input_file_path
         )
 
-        templates = config.get_templates(project_root_path)
+        templates = config.get_templates()
         lint = TaskCatLint(config, templates, strict)
         errors = lint.lints[1]
         lint.output_results()

--- a/taskcat/_cli_modules/update_ami.py
+++ b/taskcat/_cli_modules/update_ami.py
@@ -31,8 +31,11 @@ class UpdateAMI:
         else:
             _project_root = Path(project_root)
 
-        _c = Config.create(project_config_path=Path(_project_root / ".taskcat.yml"))
         _boto3cache = Boto3Cache()
+        _c = Config.create(
+            project_root=_project_root,
+            project_config_path=Path(_project_root / ".taskcat.yml"),
+        )
 
         # Stripping out any test-specific regions/auth.
         config_dict = _c.config.to_dict()

--- a/tests/test_amiupdater.py
+++ b/tests/test_amiupdater.py
@@ -724,7 +724,7 @@ class TestAMIUpdater(unittest.TestCase):
         c = Config.create(
             project_config_path=test_proj / ".taskcat.yml", project_root=test_proj
         )
-        templates = c.get_templates(project_root=test_proj)
+        templates = c.get_templates()
         return templates
 
     def test_invalid_region_exception(self):

--- a/tests/test_cfn_lint.py
+++ b/tests/test_cfn_lint.py
@@ -155,7 +155,7 @@ class TestCfnLint(unittest.TestCase):
                 config = Config.create(
                     project_config_path=config_path, project_root=project_root
                 )
-                templates = config.get_templates(project_root=project_root)
+                templates = config.get_templates()
                 lint = Lint(config=config, templates=templates)
                 self.assertEqual(
                     test_case["expected_lints"], flatten_rule(lint.lints[0])
@@ -188,7 +188,7 @@ class TestCfnLint(unittest.TestCase):
             config = Config.create(
                 project_config_path=config_path, project_root=project_root
             )
-            templates = config.get_templates(project_root)
+            templates = config.get_templates()
             lint = Lint(config=config, templates=templates)
             lint.output_results()
             self.assertTrue(
@@ -255,7 +255,7 @@ class TestCfnLint(unittest.TestCase):
             config = Config.create(
                 project_config_path=config_path, project_root=project_root
             )
-            templates = config.get_templates(project_root)
+            templates = config.get_templates()
             lint = Lint(config=config, templates=templates)
             self.assertEqual(lint.passed, True)
 

--- a/tests/test_cfn_stack.py
+++ b/tests/test_cfn_stack.py
@@ -511,7 +511,7 @@ class TestStack(unittest.TestCase):
         c = Config.create(
             project_config_path=test_proj / ".taskcat.yml", project_root=test_proj
         )
-        templates = c.get_templates(project_root=test_proj)
+        templates = c.get_templates()
         stack = Stack.create(region, "stack_name", templates["taskcat-json"])
         stack._timer.cancel()
 

--- a/tests/test_cfn_template.py
+++ b/tests/test_cfn_template.py
@@ -10,7 +10,7 @@ class TestCfnTemplate(unittest.TestCase):
         c = Config.create(
             project_config_path=test_proj / ".taskcat.yml", project_root=test_proj
         )
-        templates = c.get_templates(project_root=test_proj)
+        templates = c.get_templates()
         template = templates["taskcat-json"]
         self.assertEqual(1, len(template.children))
         self.assertEqual(4, len(template.descendents))

--- a/tests/test_cfn_threaded.py
+++ b/tests/test_cfn_threaded.py
@@ -19,18 +19,14 @@ def get_tests(test_proj, _):
         project_config_path=test_proj / ".taskcat.yml", project_root=test_proj
     )
     boto_cache = get_mock_boto_cache()
-    templates = c.get_templates(project_root=test_proj)
+    templates = c.get_templates()
     regions = c.get_regions(boto3_cache=boto_cache)
     buckets = c.get_buckets(boto_cache)
     params = c.get_rendered_parameters(buckets, regions, templates)
     return (
         c.config.project.name,
         c.get_tests(
-            project_root=test_proj,
-            templates=templates,
-            regions=regions,
-            buckets=buckets,
-            parameters=params,
+            templates=templates, regions=regions, buckets=buckets, parameters=params,
         ),
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -279,6 +279,7 @@ class TestNewConfig(unittest.TestCase):
         m_boto.client.return_value = mock_client()
         config = Config.create(
             args={},
+            project_root=base_path,
             global_config_path=base_path / ".taskcat_global.yml",
             project_config_path=base_path / "./.taskcat.yml",
             overrides_path=base_path / "./.taskcat_overrides.yml",
@@ -286,7 +287,7 @@ class TestNewConfig(unittest.TestCase):
         )
         regions = config.get_regions(boto3_cache=m_boto)
         buckets = config.get_buckets(boto3_cache=m_boto)
-        templates = config.get_templates(base_path)
+        templates = config.get_templates()
         rendered_params = config.get_rendered_parameters(buckets, regions, templates)
         for test_name, regions in rendered_params.items():
             with self.subTest(test=test_name):
@@ -299,12 +300,13 @@ class TestNewConfig(unittest.TestCase):
         base_path = Path(base_path + "data/regional_client_and_bucket").resolve()
         config = Config.create(
             args={},
+            project_root=base_path,
             global_config_path=base_path / ".taskcat_global.yml",
             project_config_path=base_path / "./.taskcat.yml",
             overrides_path=base_path / "./.taskcat_overrides.yml",
             env_vars={},
         )
-        templates = config.get_templates(base_path)
+        templates = config.get_templates()
         for test_name, _template in templates.items():
             with self.subTest(test=test_name):
                 pass


### PR DESCRIPTION
## Overview

Moving project_root to the Config obj as a convienience method. It helps cut down passing around a project root where needed. 

Tests throughout. Ran it on a project.