### PR TITLE
Better region/profile handling for update-ami subcommand

### DIFF
--- a/taskcat/_cli_modules/update_ami.py
+++ b/taskcat/_cli_modules/update_ami.py
@@ -7,8 +7,7 @@ from taskcat._amiupdater import (
     AMIUpdaterCommitNeededException,
     AMIUpdaterFatalException,
 )
-from taskcat._client_factory import Boto3Cache
-from taskcat._common_utils import exit_with_code, neglect_submodule_templates
+from taskcat._common_utils import exit_with_code
 from taskcat._config import Config
 
 LOG = logging.getLogger(__name__)
@@ -31,7 +30,6 @@ class UpdateAMI:
         else:
             _project_root = Path(project_root)
 
-        _boto3cache = Boto3Cache()
         _c = Config.create(
             project_root=_project_root,
             project_config_path=Path(_project_root / ".taskcat.yml"),
@@ -45,23 +43,12 @@ class UpdateAMI:
             if test_config.get("regions", None):
                 del test_config["regions"]
         new_config = Config.create(
-            project_config_path=Path(_project_root / ".taskcat.yml"), args=config_dict
+            project_root=_project_root,
+            project_config_path=Path(_project_root / ".taskcat.yml"),
+            args=config_dict,
         )
 
-        # Fetching the region objects.
-        regions = new_config.get_regions(boto3_cache=_boto3cache)
-        region_key = list(regions.keys())[0]
-
-        unprocessed_templates = new_config.get_templates().values()
-        finalized_templates = neglect_submodule_templates(
-            project_root=Path(_project_root), template_list=unprocessed_templates
-        )
-
-        amiupdater = AMIUpdater(
-            template_list=finalized_templates,
-            regions=regions[region_key],
-            boto3cache=_boto3cache,
-        )
+        amiupdater = AMIUpdater(config=new_config)
         try:
             amiupdater.update_amis()
         except AMIUpdaterCommitNeededException:

--- a/tests/test_amiupdater.py
+++ b/tests/test_amiupdater.py
@@ -972,12 +972,16 @@ class TestAMIUpdater(unittest.TestCase):
             AUConfig.raw_dict,
         )
 
+    @patch("taskcat._amiupdater.AMIUpdater._determine_templates", autospec=True)
     @patch("taskcat._amiupdater.AMIUpdater._determine_testable_regions", autospec=True)
     @patch("taskcat._amiupdater.Config", autospec=True)
-    def test_amiupdater__init__(self, mock_config, mock_det_test_reg):
-        resp = AMIUpdater(sentinel.template_list, sentinel.regions, sentinel.boto3cache)
+    def test_amiupdater__init__(
+        self, mock_config, mock_det_test_reg, mock_det_templates
+    ):
+        resp = AMIUpdater(sentinel.config)
         mock_config.load.assert_called_once()
         mock_det_test_reg.assert_called_once()
+        mock_det_templates.assert_called_once()
         self.assertEqual(resp.regions, mock_det_test_reg.return_value)
 
     def test_amiupdater_commit_needed_exception(self):


### PR DESCRIPTION
## Overview

Handling region reconcilation within the update-ami (well, _amiupdater) module has been not-ideal. 

This PR refactors the relevant module functions to..do..better. 

## Testing/Steps taken to ensure quality

How did you validate the changes in this PR?

unit tests. 
live tests.

### Notes

_Caveat_ This PR is dependent on #543