### PR TITLE
Batched addition of arguments throughout.

### DIFF
--- a/taskcat/_cli_core.py
+++ b/taskcat/_cli_core.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import sys
 import types
+from typing import List
 
 from taskcat._common_utils import exit_with_code
 
@@ -70,14 +71,17 @@ GLOBAL_ARGS = GlobalArgs()
 class CliCore:
     USAGE = "{prog}{global_opts}{command}{command_opts}{subcommand}{subcommand_opts}"
 
-    longform_required = []
+    longform_required: List = []
 
     @classmethod
     def longform_param_required(cls, param_name):
         def wrapper(command_func):
-            formatted_param = param_name.lower().replace('_', '-')
-            cls.longform_required.append(f"{command_func.__qualname__}.{formatted_param}")
+            formatted_param = param_name.lower().replace("_", "-")
+            cls.longform_required.append(
+                f"{command_func.__qualname__}.{formatted_param}"
+            )
             return command_func
+
         return wrapper
 
     def __init__(self, prog_name, module_package, description, version=None, args=None):

--- a/taskcat/_cli_core.py
+++ b/taskcat/_cli_core.py
@@ -8,7 +8,63 @@ import logging
 import sys
 import types
 
+from taskcat._common_utils import exit_with_code
+
 LOG = logging.getLogger(__name__)
+
+
+def _get_log_level(args, exit_func=exit_with_code):
+    log_level = "INFO"
+    if ("-d" in args or "--debug" in args) and ("-q" in args or "--quiet" in args):
+        exit_func(1, "--debug and --quiet cannot be specified simultaneously")
+    if "-d" in args or "--debug" in args:
+        log_level = "DEBUG"
+    if "-q" in args or "--quiet" in args:
+        log_level = "ERROR"
+    return log_level
+
+
+class SetVerbosity(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        LOG.setLevel(_get_log_level([option_string]))
+
+
+class GlobalArgs:
+    ARGS = [
+        [
+            ["-q", "--quiet"],
+            {
+                "action": SetVerbosity,
+                "nargs": 0,
+                "help": "reduce output to the minimum",
+                "dest": "_quiet",
+            },
+        ],
+        [
+            ["-d", "--debug"],
+            {
+                "action": SetVerbosity,
+                "nargs": 0,
+                "help": "adds debug output and tracebacks",
+                "dest": "_debug",
+            },
+        ],
+        [["--profile"], {"help": "set the default profile used.", "dest": "_profile"}],
+    ]
+
+    def __init__(self):
+        self._profile = "default"
+
+    @property
+    def profile(self):
+        return self._profile
+
+    @profile.setter
+    def profile(self, profile):
+        self._profile = profile
+
+
+GLOBAL_ARGS = GlobalArgs()
 
 
 class CliCore:

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -10,7 +10,7 @@ import yaml
 from taskcat._cfn._log_stack_events import _CfnLogTools
 from taskcat._cfn.threaded import Stacker
 from taskcat._cfn_lint import Lint as TaskCatLint
-from taskcat._cli_core import GLOBAL_ARGS, CliCore
+from taskcat._cli_core import GLOBAL_ARGS
 from taskcat._client_factory import Boto3Cache
 from taskcat._common_utils import determine_profile_for_region
 from taskcat._config import Config
@@ -116,6 +116,7 @@ class Test:
         """
         project_root_path: Path = Path(project_root).expanduser().resolve()
         input_file_path: Path = project_root_path / input_file
+        # pylint: disable=too-many-arguments
         args = _build_args(enable_sig_v2, regions, GLOBAL_ARGS.profile)
         config = Config.create(
             project_root=project_root_path,
@@ -250,7 +251,7 @@ def _trim_tests(test_names, config):
                 del config.config.tests[test]
 
 
-def _build_args(enable_sig_v2, regions):
+def _build_args(enable_sig_v2, regions, default_profile):
     args: Dict[str, Any] = {}
     if enable_sig_v2:
         args["project"] = {"s3_enable_sig_v2": enable_sig_v2}
@@ -258,4 +259,10 @@ def _build_args(enable_sig_v2, regions):
         if "project" not in args:
             args["project"] = {}
         args["project"]["regions"] = regions.split(",")
+    if default_profile:
+        _auth_dict = {"default": default_profile}
+        if not args.get("project"):
+            args["project"] = {"auth": _auth_dict}
+        else:
+            args["project"]["auth"] = _auth_dict
     return args

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -134,7 +134,8 @@ class Test:
             if errors or not lint.passed:
                 raise TaskCatException("Lint failed with errors")
         # 2. build lambdas
-        LambdaBuild(config, config.project_root)
+        if config.config.project.package_lambda:
+            LambdaBuild(config, project_root_path)
         # 3. s3 sync
         buckets = config.get_buckets(boto3_cache)
         stage_in_s3(buckets, config.config.project.name, config.project_root)

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -10,6 +10,7 @@ import yaml
 from taskcat._cfn._log_stack_events import _CfnLogTools
 from taskcat._cfn.threaded import Stacker
 from taskcat._cfn_lint import Lint as TaskCatLint
+from taskcat._cli_core import GLOBAL_ARGS, CliCore
 from taskcat._client_factory import Boto3Cache
 from taskcat._common_utils import determine_profile_for_region
 from taskcat._config import Config
@@ -115,7 +116,7 @@ class Test:
         """
         project_root_path: Path = Path(project_root).expanduser().resolve()
         input_file_path: Path = project_root_path / input_file
-        args = _build_args(enable_sig_v2, regions)
+        args = _build_args(enable_sig_v2, regions, GLOBAL_ARGS.profile)
         config = Config.create(
             project_root=project_root_path,
             project_config_path=input_file_path,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ class TestCli(unittest.TestCase):
     @mock.patch("taskcat._cli.LOG.error")
     @mock.patch("taskcat._cli._welcome", autospec=True)
     @mock.patch("taskcat._cli.get_installed_version", autospec=True)
-    @mock.patch("taskcat._cli_core.CliCore", autospec=True)
+    @mock.patch("taskcat._cli_core.CliCore")
     @mock.patch("taskcat._cli._setup_logging", autospec=True)
     @mock.patch("taskcat._common_utils.exit_with_code", autospec=True)
     @mock.patch("sys.argv", autospec=True)
@@ -23,6 +23,9 @@ class TestCli(unittest.TestCase):
     def test_main(
         self, m_signal, m_argv, m_exit, m_log_setup, m_cli, m_ver, m_welcome, m_error
     ):
+        mock_clicore_instantiation = mock.MagicMock()
+        mock_clicore_instantiation.parsed_args = mock.MagicMock()
+        m_cli.return_value = mock_clicore_instantiation
         main(cli_core_class=m_cli, exit_func=m_exit)
         self.assertEqual(True, m_signal.called)
         self.assertEqual(True, m_log_setup.called)

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -2,14 +2,13 @@ import unittest
 
 import mock
 from taskcat import _cli_modules
-from taskcat._cli import GLOBAL_ARGS
-from taskcat._cli_core import CliCore
+from taskcat._cli_core import GLOBAL_ARGS, CliCore
 
 
 class TestCliCore(unittest.TestCase):
     def test_cli_core(self):
         cli = CliCore(
-            "taskcat-test", _cli_modules, "test description", "0.1", GLOBAL_ARGS
+            "taskcat-test", _cli_modules, "test description", "0.1", GLOBAL_ARGS.ARGS
         )
         self.assertIn("lint", cli._modules)
         self.assertIn("package", cli._modules)
@@ -22,7 +21,7 @@ class TestCliCore(unittest.TestCase):
 
     def test_parse(self):
         cli = CliCore(
-            "taskcat-test", _cli_modules, "test description", "0.1", GLOBAL_ARGS
+            "taskcat-test", _cli_modules, "test description", "0.1", GLOBAL_ARGS.ARGS
         )
         cli.parser.parse_args = mock.Mock()
         actual = cli.parse()
@@ -30,7 +29,7 @@ class TestCliCore(unittest.TestCase):
 
     def test_run(self):
         cli = CliCore(
-            "taskcat-test", _cli_modules, "test description", "0.1", GLOBAL_ARGS
+            "taskcat-test", _cli_modules, "test description", "0.1", GLOBAL_ARGS.ARGS
         )
         cli._modules["lint"] = mock.Mock()
         cli.parse(["lint", "-i", "test-taskcat.yml", "-p", "./"])


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed (use case)?

This PR...
~~- adds `--output-directory` to `taskcat test run`~~
- adds `--profile` as a root-level parameter. (Ex: `taskcat --profile foo test run`)
- honors `package_lambda: false`
- Adds decorators that allow us to further customize the argument behavior. 

### Law of Unintended Consequences

Adding `--profile` as a root-level argument means that it's passed to every subbcommand module. For now, simply adding `*_args, **_kwargs` to each module class settles it. However, this means that each subcommand may behave differently. We may want to centralize a bare-bones config object (OR - args) to pass-through so that when a new subcommand is added, it's not missed. 

Would very much appreciate feedback on this caveat, as it directly impacts another PR that I have in the works.

### Decorators

Two decorators are added 
- `CliCore.dont_generate_parameter`
- `CliCore.longform_param_required`

These decorators allow us to turn on/off parameter generation, and enforce longform parameters. 

On/off example is `profile` in `taskcat._cli_modules.Test.run`.
```python
    @CliCore.longform_param_required('custom_uid')
    @CliCore.dont_generate_parameter('profile')
    def run(  # noqa: C901
        test_names: str = "ALL",
        regions: str = "ALL",
        input_file: str = "./.taskcat.yml",
        project_root: str = "./",
        no_delete: bool = False,
        lint_disable: bool = False,
        enable_sig_v2: bool = False,
        keep_failed: bool = False,
        output_directory: str = './taskcat_outputs',
        profile: str = "default"
    ):
```

It's passed from the global argparser instance, but generating another parameter conflicts because `-p/--project-root` conflicts with the default naming `-p/--profile`. Redefining this parameter isn't necessary, so we're passing it from the root-level parser, but not asking for it again. 

The longform enforcer is, well, face-value. There are certain parameters that we may want to enforce the long-form of them. 

- Ex: `taskcat test run --super-dangerous-action-yes-i-understand`. In the current behavior, the arguments accepted would be `-s/--super-dangerous-yes-i-understand`. 

## Testing/Steps taken to ensure quality

How did you validate the changes in this PR?
- Unit tests. 
- by hand. 


 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output