### PR TITLE
Fixed formatting for black for PR #558

### DIFF
--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -97,7 +97,7 @@ class Test:
         lint_disable: bool = False,
         enable_sig_v2: bool = False,
         keep_failed: bool = False,
-        output_directory: str = './taskcat_outputs',
+        output_directory: str = "./taskcat_outputs",
     ):
         """tests whether CloudFormation templates are able to successfully launch
 
@@ -110,7 +110,7 @@ class Test:
         :param lint_disable: disable cfn-lint checks
         :param enable_sig_v2: enable legacy sigv2 requests for auto-created buckets
         :param keep_failed: do not delete failed stacks
-        :param output_directory: Where to store generated logfiles
+        :param output_directory: where to store generated logfiles
         """
         project_root_path: Path = Path(project_root).expanduser().resolve()
         input_file_path: Path = project_root_path / input_file


### PR DESCRIPTION
## Overview

This PR fixes formatting for black for PR #558

## Testing/Steps taken to ensure quality

Ran black manually, file is left unchanged.

## Testing Instructions

1. Run taskcat with defaults: `taskcat test run`. Expected outcome: reports are generated in `./taskcat_outputs`
2. Run taskcat with argument: `taskcat test run --output_directory ./build/taskcat`. Expected outcome: reports are generated in `./build/taskcat`