### PR TITLE
add minimal-output and dont-wait-for-delete flags

### DIFF
--- a/taskcat/_cfn/_log_stack_events.py
+++ b/taskcat/_cfn/_log_stack_events.py
@@ -22,7 +22,6 @@ class _CfnLogTools:
         return stack.events(refresh=True)
 
     def get_cfnlogs(self, stack: Stack):
-        LOG.info(f"Collecting logs for {stack.name}")
         # Collect stack_events
         stack_events = self.get_cfn_stack_events(stack)
         events = []
@@ -43,7 +42,6 @@ class _CfnLogTools:
         return events
 
     def createcfnlogs(self, stacks: Stacker, logpath: Path):
-        LOG.info("Collecting CloudFormation Logs")
         for stack in stacks.stacks:
             stackname = stack.name
             region = stack.region_name
@@ -69,23 +67,6 @@ class _CfnLogTools:
             else:
                 reason = "Stack launch was successful"
 
-            LOG.info("\t |StackName: " + stackname)
-            LOG.info("\t |Region: " + region)
-            LOG.info("\t |Logging to: " + str(logpath))
-            LOG.info(
-                "\t |Tested on: "
-                + str(datetime.datetime.now().strftime("%A, %d. %B %Y %I:%M%p"))
-            )
-            LOG.info(
-                "----------------------------------------------------------------------"
-                "--------------------"
-            )
-            LOG.info("ResourceStatusReason: ")
-            LOG.info(textwrap.fill(str(reason), 85))
-            LOG.info(
-                "======================================================================"
-                "===================="
-            )
             with open(str(logpath), "a") as log_output:
                 log_output.write(
                     "------------------------------------------------------------------"

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -42,7 +42,7 @@ class Test:
         no_delete: bool = False,
         keep_failed: bool = False,
         minimal_output: bool = False,
-        dont_wait_for_delete: bool = True,
+        dont_wait_for_delete: bool = False,
     ):
         """[ALPHA] re-launches a child stack using the same parameters as previous
         launch
@@ -116,7 +116,7 @@ class Test:
         keep_failed: bool = False,
         output_directory: str = "./taskcat_outputs",
         minimal_output: bool = False,
-        dont_wait_for_delete: bool = True,
+        dont_wait_for_delete: bool = False,
     ):
         """tests whether CloudFormation templates are able to successfully launch
 

--- a/taskcat/_tui.py
+++ b/taskcat/_tui.py
@@ -37,6 +37,7 @@ class TerminalPrinter:
         _status_dict = stacker.status()
         history: dict = {}
         while self._is_test_in_progress(_status_dict):
+            _status_dict = stacker.status()
             for stack in stacker.stacks:
                 self._print_tree_minimal(stack, history)
             time.sleep(poll_interval)


### PR DESCRIPTION
## Overview
add 2 flags to `test run` subcommand:

`--minimal-output` flag doesn't use the terminal printer, and only prints stack status when it changes. output looks like:

```
[INFO   ] : monitoring-prom-graf ap-southeast-2 CREATE_IN_PROGRESS
[ERROR  ] : monitoring-prom-graf ap-southeast-2 CREATE_FAILED
[ERROR  ] :     GrafanaHelmChart AWS Error: ResourceConflictException - Function already exist: helm-provider-vpc-connector-8c1f98b277d5eed33a85f2dc07e4c71c <nil>
[INFO   ] : monitoring-prom-graf ap-southeast-2 DELETE_IN_PROGRESS
[INFO   ] : monitoring-prom-graf ap-southeast-2 DELETE_COMPLETE
```

`--dont-wait-for-delete` flag calls delete_stack and then exits without waiting to see if stack delete is successful. 