### PR TITLE
facilitate decoupled upload and test

### DIFF
--- a/taskcat/_cli_modules/__init__.py
+++ b/taskcat/_cli_modules/__init__.py
@@ -5,3 +5,4 @@ from .list import List  # noqa: F401
 from .package import Package  # noqa: F401
 from .test import Test  # noqa: F401
 from .update_ami import UpdateAMI  # noqa: F401
+from .upload import Upload  # noqa: F401

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -72,7 +72,7 @@ class Test:
         resource = [i for i in events if i["LogicalResourceId"] == resource_name][0]
         properties = yaml.safe_load(resource["ResourceProperties"])
 
-        with open(".taskcat.yml", "r") as filepointer:
+        with open(str(input_file_path), "r") as filepointer:
             config_yaml = yaml.safe_load(filepointer)
 
         config_yaml["project"]["regions"] = [region]
@@ -125,7 +125,7 @@ class Test:
         :param regions: comma separated list of regions to test in
         :param input_file: path to either a taskat project config file or a
         CloudFormation template
-        :param project_root_path: root path of the project relative to input_file
+        :param project_root: root path of the project relative to input_file
         :param no_delete: don't delete stacks after test is complete
         :param lint_disable: disable cfn-lint checks
         :param enable_sig_v2: enable legacy sigv2 requests for auto-created buckets

--- a/taskcat/_cli_modules/upload.py
+++ b/taskcat/_cli_modules/upload.py
@@ -1,0 +1,51 @@
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from taskcat._client_factory import Boto3Cache
+from taskcat._config import Config
+from taskcat._lambda_build import LambdaBuild
+from taskcat._s3_stage import stage_in_s3
+
+LOG = logging.getLogger(__name__)
+
+
+class Upload:
+    """
+    Uploads project to S3.
+    """
+
+    def __init__(
+        self,
+        config_file: str = "./.taskcat.yml",
+        project_root: str = "./",
+        enable_sig_v2: bool = False,
+        bucket_name: str = "",
+        disable_lambda_packaging: bool = False,
+    ):
+        """does lambda packaging and uploads to s3
+
+        :param config_file: path to taskat project config file
+        :param enable_sig_v2: enable legacy sigv2 requests for auto-created buckets
+        :param bucket_name: set bucket name instead of generating it. If regional
+        buckets are enabled, will use this as a prefix
+        :param disable_lambda_packaging: skip packaging step
+        """
+        project_root_path: Path = Path(project_root).expanduser().resolve()
+        input_file_path: Path = project_root_path / config_file
+        args: Dict[str, Any] = {"project": {"s3_enable_sig_v2": enable_sig_v2}}
+        if bucket_name:
+            args["project"]["bucket_name"] = bucket_name
+        config = Config.create(
+            project_root=project_root_path,
+            project_config_path=input_file_path,
+            args=args,
+        )
+        boto3_cache = Boto3Cache()
+        if (
+            config.config.project.package_lambda
+            and disable_lambda_packaging is not True
+        ):
+            LambdaBuild(config, project_root_path)
+        buckets = config.get_buckets(boto3_cache)
+        stage_in_s3(buckets, config.config.project.name, config.project_root)

--- a/taskcat/_lambda_build.py
+++ b/taskcat/_lambda_build.py
@@ -159,3 +159,4 @@ class LambdaBuild:
         except ReadTimeout:
             LOG.warning(f"Could not remove container {container.id}")
         os.unlink(tmpfile.name)
+        os.removedirs(str(package_path / "output"))

--- a/taskcat/_s3_stage.py
+++ b/taskcat/_s3_stage.py
@@ -38,4 +38,3 @@ def stage_in_s3(buckets, project_name, project_root):
 
 def _sync_wrap(bucket, project_name, project_root):
     S3Sync(bucket.s3_client, bucket.name, project_name, project_root, bucket.object_acl)
->>>>>>> thread uploads

--- a/tests/test_cli_module_test.py
+++ b/tests/test_cli_module_test.py
@@ -18,3 +18,33 @@ class TestTestCli(unittest.TestCase):
         mock_report_builder.assert_called()
         mock_lambda_build.assert_called()
         mock_config.create.assert_called()
+
+    @mock.patch("taskcat._cli_modules.test.Config", autospec=True)
+    @mock.patch("taskcat._cli_modules.test.Test", autospec=True)
+    @mock.patch("taskcat._cli_modules.test.boto3.Session", autospec=True)
+    def test_test_retry(self, mock_boto_session, mock_test, mock_config):
+        base_path = "./" if os.getcwd().endswith("/tests") else "./tests/"
+        base_path = Path(base_path + "data/nested-fail").resolve()
+        mock_client = mock.MagicMock()
+        mock_describe = mock.MagicMock()
+        mock_describe.return_value = {
+            "StackEvents": [
+                {
+                    "PhysicalResourceId": "pid",
+                    "LogicalResourceId": "MyResource",
+                    "ResourceProperties": '{"Parameters": [], "TemplateURL": '
+                    '"https://some/url"}',
+                }
+            ]
+        }
+        mock_client.return_value.describe_stack_events = mock_describe
+        mock_boto_session.return_value.client = mock_client
+        Test.retry(
+            project_root=base_path,
+            config_file=base_path / ".taskcat.yml",
+            region="us-east-1",
+            stack_name="test-stack",
+            resource_name="MyResource",
+        )
+        mock_config.create.assert_called()
+        mock_test.run.assert_called()


### PR DESCRIPTION
## Overview

two changes here:

* adds `taskcat upload` command that uploads to s3, but does not run tests. Fixes #547
* adds `--skip-upload` to `taskcat test run` that does not upload anything to s3

This facilitates the following use-cases:

*use as an uploader/publisher* - taskcat can now be used to publish to s3
*test already staged projects* - can test projects previously staged, taskcat as a canary

Consider the following project config:

```
project:
  name: quickstart-amazon-eks-develop
  template: templates/amazon-eks-master.template.yaml
  s3_bucket: aws-quickstart
  parameters:
    RemoteAccessCIDR: 10.0.0.0/16
    QSS3BucketName: aws-quickstart
    QSS3KeyPrefix: quickstart-amazon-eks-develop/
    AvailabilityZones: $[taskcat_genaz_3]
tests:
  default-entrypoint:
    s3_regional_buckets: false
    regions:
      - us-east-1
    parameters:
      AvailabilityZones: $[taskcat_genaz_3]
      ProvisionBastionHost: Disabled
  regional-entrypoint:
    s3_regional_buckets: true
    regions:
      - eu-central-1
```

Running `taskcat test run` against this would result in artifacts being uploaded to the `aws-quickstart` and `aws-quickstart-eu-central-1` buckets with the key prefix `quickstart-amazon-eks-develop/`. One stack will be launched in each region, `default-entrypoint` will have `https://aws-quickstart.s3.us-east-1.amazonaws.com/quickstart-amazon-eks-develop/templates/amazon-eks-master.template.yaml` as the TemplateURL and `regional-entrypoint` will have `https://aws-quickstart-eu-central-1.s3.us-east-1.amazonaws.com/quickstart-amazon-eks-develop/templates/amazon-eks-master.template.yaml`.

If the project.name and project.parameters.QSS3KeyPrefix are updated to the prod name (`quickstart-amazon-eks`) and taskcat is invoked with `taskcat test run --skip-upload` then the tests will run against the existing assets in production bucket/prefix.
