### PR TITLE
Invoking StackURLHelper so that it replaces variables with parameters

### DIFF
--- a/taskcat/_cfn/stack_url_helper.py
+++ b/taskcat/_cfn/stack_url_helper.py
@@ -108,7 +108,7 @@ class StackURLHelper:
         # replace each key we have a value for
         for key in values:
             rep_text = "##" + key + "##"
-            rep_with = "" + values[key] + ""
+            rep_with = "" + str(values[key]) + ""
 
             result = result.replace(rep_text, rep_with)
 

--- a/taskcat/_cfn/template.py
+++ b/taskcat/_cfn/template.py
@@ -86,22 +86,18 @@ class Template:
         self.template = cfnlint.decode.cfn_yaml.load(self.template_path)
         self._find_children()
 
-    @staticmethod
     def _template_url_to_path(
-        current_template_path,
-        template_url,
-        template_mappings=None,
-        template_parameters=None,
+        self, template_url, template_mappings=None,
     ):
         try:
 
             helper = StackURLHelper(
                 template_mappings=template_mappings,
-                template_parameters=template_parameters,
+                template_parameters=self.template.get("Parameters"),
             )
 
             urls = helper.template_url_to_path(
-                current_template_path=current_template_path, template_url=template_url,
+                current_template_path=self.template_path, template_url=template_url
             )
 
             if len(urls) > 0:
@@ -146,7 +142,6 @@ class Template:
             resource = self.template["Resources"][resource]
             if resource["Type"] == "AWS::CloudFormation::Stack":
                 child_name = self._template_url_to_path(
-                    current_template_path=self.template_path,
                     template_url=resource["Properties"]["TemplateURL"],
                 )
                 # print(child_name)


### PR DESCRIPTION
The previous invocation method of StackURLHelper didn't pass in any parameters for the template. The net-result was that StackURLHelper didn't replace template parameters in a URL with (at minimum) their default values. 

Note: There's still an outstanding issue where we don't pass in the parameter values but this solves my immediate issue. 