### PR TITLE
Batch Bug Fixes and Feature additions

### DIFF
--- a/taskcat/_cfn/threaded.py
+++ b/taskcat/_cfn/threaded.py
@@ -62,14 +62,8 @@ class Stacker:
         ]
         fan_out(self._create_stacks_for_test, {"tags": tags}, tests, threads)
 
-    def _get_stack_name_for_test(self, test):
-        prefix = f"{self.stack_name_prefix}-" if self.stack_name_prefix else ""
-        if self.shorten_stack_name:
-            return "{}{}-{}".format(prefix, test.name, self.uid.hex[:6])
-        return "{}{}-{}-{}".format(prefix, self.project_name, test.name, self.uid.hex)
-
     def _create_stacks_for_test(self, test, tags, threads: int = 32):
-        stack_name = self._get_stack_name_for_test(test)
+        stack_name = test.stack_name
         tags.append(Tag({"Key": "taskcat-project-name", "Value": self.project_name}))
         tags.append(Tag({"Key": "taskcat-test-name", "Value": test.name}))
         tags += test.tags

--- a/taskcat/_common_utils.py
+++ b/taskcat/_common_utils.py
@@ -222,11 +222,13 @@ def fetch_ssm_parameter_value(boto_client, parameter_path):
     response = ssm.get_parameter(Name=parameter_path)
     return response["Parameter"]["Value"]
 
+
 def fetch_secretsmanager_parameter_value(boto_client, secret_arn):
-    secrets_manager = boto_client('secretsmanager')
+    secrets_manager = boto_client("secretsmanager")
     try:
-        response = secrets_manager.get_secret_value(
-            SecretId=secret_arn
+        response = secrets_manager.get_secret_value(SecretId=secret_arn)["SecretString"]
+    except Exception as e:
+        raise TaskCatException(
+            "ARN: {} encountered an error: {}".format(secret_arn, str(e))
         )
-    except TaskCatException as e:
-        raise TaskCatException("ARN: {} encountered a")
+    return response

--- a/taskcat/_common_utils.py
+++ b/taskcat/_common_utils.py
@@ -221,3 +221,12 @@ def fetch_ssm_parameter_value(boto_client, parameter_path):
     ssm = boto_client("ssm")
     response = ssm.get_parameter(Name=parameter_path)
     return response["Parameter"]["Value"]
+
+def fetch_secretsmanager_parameter_value(boto_client, secret_arn):
+    secrets_manager = boto_client('secretsmanager')
+    try:
+        response = secrets_manager.get_secret_value(
+            SecretId=secret_arn
+        )
+    except TaskCatException as e:
+        raise TaskCatException("ARN: {} encountered a")

--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -363,7 +363,7 @@ class Config:
                 region = region_objects[test_name][region_name]
                 s3bucket = bucket_objects[test_name][region_name]
                 parameters[test_name][region_name] = ParamGen(
-                    region_params, s3bucket.name, region.name, region.client
+                    region_params, s3bucket.name, region.name, region.client, self.config.project.name, test_name
                 ).results
         return parameters
 

--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -369,7 +369,7 @@ class Config:
                     region.client,
                     self.config.project.name,
                     test_name,
-                    test.az_blacklist
+                    test.az_blacklist,
                 ).results
         return parameters
 
@@ -414,5 +414,8 @@ class Config:
                 project_root=self.project_root,
                 regions=region_list,
                 tags=tag_list,
+                uid=self.uid,
+                _project_name=self.config.project.name,
+                _shorten_stack_name=self.config.project.shorten_stack_name,
             )
         return tests

--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -363,7 +363,13 @@ class Config:
                 region = region_objects[test_name][region_name]
                 s3bucket = bucket_objects[test_name][region_name]
                 parameters[test_name][region_name] = ParamGen(
-                    region_params, s3bucket.name, region.name, region.client, self.config.project.name, test_name
+                    region_params,
+                    s3bucket.name,
+                    region.name,
+                    region.client,
+                    self.config.project.name,
+                    test_name,
+                    test.az_blacklist
                 ).results
         return parameters
 

--- a/taskcat/_template_params.py
+++ b/taskcat/_template_params.py
@@ -35,8 +35,8 @@ class ParamGen:
     RE_PROJECT_NAME = re.compile(r"\$\[taskcat_project_name]", re.IGNORECASE)
     RE_TEST_NAME = re.compile(r"\$\[taskcat_test_name]", re.IGNORECASE)
     RE_SSM_PARAMETER = re.compile(r"\$\[taskcat_ssm_.*]$", re.IGNORECASE)
+    # RE_SECRETSMANAGER_PARAMETER = re.compile(r"\$\[taskcat_secretsmanager_.*]$", re.IGNORECASE)
 
-    def __init__(self, param_dict, bucket_name, region, boto_client, az_excludes=None):
     def __init__(self, param_dict, bucket_name, region, boto_client, project_name, test_name, az_excludes=None):
         self.regxfind = CommonTools.regxfind
         self._param_dict = param_dict
@@ -393,6 +393,10 @@ class ParamGen:
             param_path = "_".join(ssm_value_str[:-1].split("_")[2:])
             param_value = fetch_ssm_parameter_value(self._boto_client, param_path)
             self._regex_replace_param_value(re.compile("^.*"), param_value)
+
+    # def _get_secretsmanager_param_value_wrapper(self, secretsmanager_param_value_regex):
+    #     if secretsmanager_param_value_regex.search(self.param_value):
+    #         sm_value_str = self.regxfind(secretsmanager_param_value_regex, self.param_value)
 
     def _getval_wrapper(self, getval_regex):
         if getval_regex.search(self.param_value):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,7 +1,11 @@
 import unittest
+import uuid
+from pathlib import Path
 
 from dataclasses_jsonschema import ValidationError
-from taskcat._dataclasses import ProjectConfig
+from taskcat._config import Config
+from taskcat._dataclasses import ProjectConfig, TestObj
+from taskcat.exceptions import TaskCatException
 
 
 class TestNewConfig(unittest.TestCase):
@@ -22,3 +26,162 @@ class TestNewConfig(unittest.TestCase):
         for acl in valid:
             p = ProjectConfig(s3_object_acl=acl).to_dict(validate=True)
             self.assertEqual(p["s3_object_acl"], acl)
+
+
+class TestTestObj(unittest.TestCase):
+    def test_stack_name(self):
+        test_proj = (Path(__file__).parent / "./data/nested-fail").resolve()
+        c = Config.create(
+            project_config_path=test_proj / ".taskcat.yml", project_root=test_proj
+        )
+        templates = c.get_templates()
+        template = templates["taskcat-json"]
+
+        example_uuid = uuid.uuid4()
+
+        # Assert full stack name
+        test_obj = TestObj(
+            name="foobar",
+            template_path=template.template_path,
+            template=template.template,
+            project_root=template.project_root,
+            regions=[],
+            tags=[],
+            uid=example_uuid,
+            _stack_name="foobar-more-coffee",
+            _project_name="example-proj",
+        )
+        expected = "foobar-more-coffee"
+        actual = test_obj.stack_name
+        self.assertEqual(expected, actual)
+
+        # Assert stack prefix
+        test_obj = TestObj(
+            name="foobar",
+            template_path=template.template_path,
+            template=template.template,
+            project_root=template.project_root,
+            regions=[],
+            tags=[],
+            uid=example_uuid,
+            _stack_name_prefix="blah-",
+            _project_name="example-proj",
+        )
+        expected = "blah-example-proj-foobar-{}".format(example_uuid.hex)
+        actual = test_obj.stack_name
+        self.assertEqual(expected, actual)
+
+        # Assert stack prefix short
+        test_obj = TestObj(
+            name="foobar",
+            template_path=template.template_path,
+            template=template.template,
+            project_root=template.project_root,
+            regions=[],
+            tags=[],
+            uid=example_uuid,
+            _stack_name_prefix="blah-",
+            _project_name="example-proj",
+            _shorten_stack_name=True,
+        )
+        expected = "blah-foobar-{}".format(example_uuid.hex[:6])
+        actual = test_obj.stack_name
+        self.assertEqual(expected, actual)
+
+        # Assert stack suffix
+        test_obj = TestObj(
+            name="foobar",
+            template_path=template.template_path,
+            template=template.template,
+            project_root=template.project_root,
+            regions=[],
+            tags=[],
+            uid=example_uuid,
+            _stack_name_suffix="asdf",
+            _project_name="example-proj",
+        )
+        expected = "tCaT-example-proj-foobar-asdf"
+        actual = test_obj.stack_name
+        self.assertEqual(expected, actual)
+
+        # Assert no customizations.
+        test_obj = TestObj(
+            name="foobar",
+            template_path=template.template_path,
+            template=template.template,
+            project_root=template.project_root,
+            regions=[],
+            tags=[],
+            uid=example_uuid,
+            _project_name="example-proj",
+        )
+        expected = f"tCaT-example-proj-foobar-{example_uuid.hex}"
+        actual = test_obj.stack_name
+        self.assertEqual(expected, actual)
+
+        # Assert only short stack name.
+        test_obj = TestObj(
+            name="foobar",
+            template_path=template.template_path,
+            template=template.template,
+            project_root=template.project_root,
+            regions=[],
+            tags=[],
+            uid=example_uuid,
+            _project_name="example-proj",
+            _shorten_stack_name=True,
+        )
+        expected = "tCaT-foobar-{}".format(example_uuid.hex[:6])
+        actual = test_obj.stack_name
+        self.assertEqual(expected, actual)
+
+    def test_param_combo_assert(self):
+        test_proj = (Path(__file__).parent / "./data/nested-fail").resolve()
+        c = Config.create(
+            project_config_path=test_proj / ".taskcat.yml", project_root=test_proj
+        )
+        templates = c.get_templates()
+        template = templates["taskcat-json"]
+
+        example_uuid = uuid.uuid4()
+
+        # Assert full stack name
+        with self.assertRaises(TaskCatException):
+            _ = TestObj(
+                name="foobar",
+                template_path=template.template_path,
+                template=template.template,
+                project_root=template.project_root,
+                regions=[],
+                tags=[],
+                uid=example_uuid,
+                _stack_name="foobar-more-coffee",
+                _stack_name_prefix="blah",
+                _project_name="example-proj",
+            )
+        with self.assertRaises(TaskCatException):
+            _ = TestObj(
+                name="foobar",
+                template_path=template.template_path,
+                template=template.template,
+                project_root=template.project_root,
+                regions=[],
+                tags=[],
+                uid=example_uuid,
+                _stack_name="foobar-more-coffee",
+                _stack_name_suffix="blah",
+                _project_name="example-proj",
+            )
+        with self.assertRaises(TaskCatException):
+            _ = TestObj(
+                name="foobar",
+                template_path=template.template_path,
+                template=template.template,
+                project_root=template.project_root,
+                regions=[],
+                tags=[],
+                uid=example_uuid,
+                _stack_name_prefix="foo",
+                _stack_name_suffix="blah",
+                _project_name="example-proj",
+            )

--- a/tests/test_template_params.py
+++ b/tests/test_template_params.py
@@ -152,8 +152,8 @@ class TestParamGen(unittest.TestCase):
         "bucket_name": "tcat-tag-skdfklsdfklsjf",
         "region": "us-east-1",
         "project_name": "foobar",
-        "test_name":"testy_mc_testerson",
-        "boto_client": client_factory_instance()
+        "test_name": "testy_mc_testerson",
+        "boto_client": client_factory_instance(),
     }
     rp_namedtup = namedtuple("RegexTestPattern", "test_string test_pattern_attribute")
     regex_patterns = [
@@ -244,13 +244,16 @@ class TestParamGen(unittest.TestCase):
             test_pattern_attribute="RE_SSM_PARAMETER",
         ),
         rp_namedtup(
-            test_string="$[taskcat_project_name]",
-            test_pattern_attribute="RE_PROJECT_NAME"
+            test_string="$[taskcat_secretsmanager_arn:aws:blah]",
+            test_pattern_attribute="RE_SECRETSMANAGER_PARAMETER",
         ),
         rp_namedtup(
-            test_string="$[taskcat_test_name]",
-            test_pattern_attribute="RE_TEST_NAME"
-        )
+            test_string="$[taskcat_project_name]",
+            test_pattern_attribute="RE_PROJECT_NAME",
+        ),
+        rp_namedtup(
+            test_string="$[taskcat_test_name]", test_pattern_attribute="RE_TEST_NAME"
+        ),
     ]
 
     def test_regxfind(self):
@@ -519,9 +522,7 @@ class TestParamGen(unittest.TestCase):
         self.assertEqual(pg.param_value, "blah")
 
     def test__get_project_name(self):
-        input_params = {
-            "Project_Name": "$[taskcat_project_name]"
-        }
+        input_params = {"Project_Name": "$[taskcat_project_name]"}
         bclient = MockClient
         bclient.logger = logger
         class_kwargs = self.class_kwargs
@@ -529,15 +530,11 @@ class TestParamGen(unittest.TestCase):
         class_kwargs["boto_client"] = bclient
         pg = ParamGen(**class_kwargs)
         pg.transform_parameter()
-        expected_result = {
-            "Project_Name": "foobar"
-        }
+        expected_result = {"Project_Name": "foobar"}
         self.assertEqual(pg.results, expected_result)
 
     def test__get_test_name(self):
-        input_params = {
-            "Test_Name": "$[taskcat_test_name]"
-        }
+        input_params = {"Test_Name": "$[taskcat_test_name]"}
         bclient = MockClient
         bclient.logger = logger
         class_kwargs = self.class_kwargs
@@ -545,7 +542,5 @@ class TestParamGen(unittest.TestCase):
         class_kwargs["boto_client"] = bclient
         pg = ParamGen(**class_kwargs)
         pg.transform_parameter()
-        expected_result = {
-            "Test_Name": "testy_mc_testerson"
-        }
+        expected_result = {"Test_Name": "testy_mc_testerson"}
         self.assertEqual(pg.results, expected_result)

--- a/tests/test_template_params.py
+++ b/tests/test_template_params.py
@@ -151,7 +151,9 @@ class TestParamGen(unittest.TestCase):
         "param_dict": {},
         "bucket_name": "tcat-tag-skdfklsdfklsjf",
         "region": "us-east-1",
-        "boto_client": client_factory_instance(),
+        "project_name": "foobar",
+        "test_name":"testy_mc_testerson",
+        "boto_client": client_factory_instance()
     }
     rp_namedtup = namedtuple("RegexTestPattern", "test_string test_pattern_attribute")
     regex_patterns = [
@@ -241,6 +243,14 @@ class TestParamGen(unittest.TestCase):
             test_string="$[taskcat_ssm_/aws/foo/bar/blah]",
             test_pattern_attribute="RE_SSM_PARAMETER",
         ),
+        rp_namedtup(
+            test_string="$[taskcat_project_name]",
+            test_pattern_attribute="RE_PROJECT_NAME"
+        ),
+        rp_namedtup(
+            test_string="$[taskcat_test_name]",
+            test_pattern_attribute="RE_TEST_NAME"
+        )
     ]
 
     def test_regxfind(self):
@@ -507,3 +517,35 @@ class TestParamGen(unittest.TestCase):
             bclient, "/path/to/my/example/ssm_param/nested_with_underscores"
         )
         self.assertEqual(pg.param_value, "blah")
+
+    def test__get_project_name(self):
+        input_params = {
+            "Project_Name": "$[taskcat_project_name]"
+        }
+        bclient = MockClient
+        bclient.logger = logger
+        class_kwargs = self.class_kwargs
+        class_kwargs["param_dict"] = input_params
+        class_kwargs["boto_client"] = bclient
+        pg = ParamGen(**class_kwargs)
+        pg.transform_parameter()
+        expected_result = {
+            "Project_Name": "foobar"
+        }
+        self.assertEqual(pg.results, expected_result)
+
+    def test__get_test_name(self):
+        input_params = {
+            "Test_Name": "$[taskcat_test_name]"
+        }
+        bclient = MockClient
+        bclient.logger = logger
+        class_kwargs = self.class_kwargs
+        class_kwargs["param_dict"] = input_params
+        class_kwargs["boto_client"] = bclient
+        pg = ParamGen(**class_kwargs)
+        pg.transform_parameter()
+        expected_result = {
+            "Test_Name": "testy_mc_testerson"
+        }
+        self.assertEqual(pg.results, expected_result)


### PR DESCRIPTION
- Adding "$[taskcat_project_name]" and "$[taskcat_test_name]". Closes #550
- Fixing AZ Blacklist passthrough; Closes #551 
- Adds SecretsManager support; Closes #530 Closes #581 
- Adds support for fixed stack name, stack prefix, stack suffix.

Plus unit tests.