### PR TITLE
More stringent critera for successful tests, cosmetic improvment to linting behavior

### DIFF
--- a/e2e/tests/lint.sh
+++ b/e2e/tests/lint.sh
@@ -12,7 +12,7 @@ if [[ ${EXIT_CODE} -ne 0 ]] ; then
     exit 1
 fi
 
-if [[ $(cat /tmp/output | grep -c "Lint passed for test mytest on template") -ne 1 ]]
+if [[ $(cat /tmp/output | egrep -c "Linting passed for file:.*/tests/data/lambda_build_with_submodules/templates/test.template.yaml") -ne 1 ]]
 then
     echo '$ taskcat lint -p ./tests/data/lambda_build_with_submodules'
     cat /tmp/output
@@ -30,7 +30,7 @@ if [[ ${EXIT_CODE} -ne 0 ]] ; then
     exit 1
 fi
 
-if [[ $(cat /tmp/output | grep -c "Lint passed for test taskcat-json on template ") -ne 5 ]]
+if [[ $(cat /tmp/output | grep -c "Linting passed for file:.*/tests/data/nested-fail/templates/test.*.yaml") -ne 5 ]]
 then
     echo '$ taskcat lint -p ./tests/data/nested-fail'
     cat /tmp/output

--- a/taskcat/_amiupdater.py
+++ b/taskcat/_amiupdater.py
@@ -37,6 +37,7 @@ class Config:
                 cls.raw_dict = yaml.safe_load(_f)
             except yaml.YAMLError as e:
                 LOG.error(f"[{file_name}] - YAML Syntax Error!")
+                # pylint: disable=raise-missing-from
                 raise AMIUpdaterFatalException(str(e))
         try:
             for _x in cls.raw_dict.get("global").get("AMIs").keys():
@@ -47,6 +48,7 @@ class Config:
                 f"{configtype} config file [{file_name}]" f"is not structured properly!"
             )
             LOG.error(f"{e}")
+            # pylint: disable=raise-missing-from
             raise AMIUpdaterFatalException(str(e))
 
     @classmethod
@@ -152,12 +154,14 @@ class AMIUpdaterFatalException(TaskCatException):
     """Raised when AMIUpdater experiences a fatal error"""
 
     def __init__(self, message=None):
+        # pylint: disable=super-with-arguments
         super(AMIUpdaterFatalException, self).__init__(message)
         self.message = message
 
 
 class AMIUpdaterCommitNeededException(TaskCatException):
     def __init__(self, message=None):
+        # pylint: disable=super-with-arguments
         super(AMIUpdaterCommitNeededException, self).__init__(message)
         self.message = message
 

--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -211,6 +211,8 @@ class Test:
                         bucket.delete(delete_objects=True)
                         deleted.append(bucket.name)
         # 9. raise if something failed
+        # - grabbing the status again to ensure everything deleted OK.
+        status = test_definition.status()
         if len(status["FAILED"]) > 0:
             raise TaskCatException(
                 f'One or more stacks failed tests: {status["FAILED"]}'

--- a/taskcat/_client_factory.py
+++ b/taskcat/_client_factory.py
@@ -94,17 +94,20 @@ class Boto3Cache:
             account_id = sts_client.get_caller_identity()["Account"]
         except ClientError as e:
             if e.response["Error"]["Code"] == "AccessDenied":
+                # pylint: disable=raise-missing-from
                 raise TaskCatException(
                     f"Not able to fetch account number from {region} using profile "
                     f"{profile}. {str(e)}"
                 )
             raise
         except NoCredentialsError as e:
+            # pylint: disable=raise-missing-from
             raise TaskCatException(
                 f"Not able to fetch account number from {region} using profile "
                 f"{profile}. {str(e)}"
             )
         except ProfileNotFound as e:
+            # pylint: disable=raise-missing-from
             raise TaskCatException(
                 f"Not able to fetch account number from {region} using profile "
                 f"{profile}. {str(e)}"

--- a/taskcat/_common_utils.py
+++ b/taskcat/_common_utils.py
@@ -49,6 +49,7 @@ def s3_url_maker(bucket, key, s3_client, autobucket=False):
                 resp = requests.get(f"https://{bucket}.s3.amazonaws.com/{key}")
                 location = resp.headers.get("x-amz-bucket-region")
                 if not location:
+                    # pylint: disable=raise-missing-from
                     raise TaskCatException(
                         f"failed to discover region for bucket {bucket}"
                     )
@@ -71,6 +72,7 @@ def get_s3_domain(region):
     try:
         return S3_PARTITION_MAP[REGIONS[region]]
     except KeyError:
+        # pylint: disable=raise-missing-from
         raise TaskCatException(f"cannot find the S3 hostname for region {region}")
 
 
@@ -120,16 +122,19 @@ def param_list_to_dict(original_keys):
     # - Used to give an Parameter => Index mapping for replacement.
     param_index = {}
     if not isinstance(original_keys, list):
+        # pylint: disable=raise-missing-from
         raise TaskCatException(
             'Invalid parameter file, outermost json element must be a list ("[]")'
         )
     for (idx, param_dict) in enumerate(original_keys):
         if not isinstance(param_dict, dict):
+            # pylint: disable=raise-missing-from
             raise TaskCatException(
                 'Invalid parameter %s parameters must be of type dict ("{}")'
                 % param_dict
             )
         if "ParameterKey" not in param_dict or "ParameterValue" not in param_dict:
+            # pylint: disable=raise-missing-from
             raise TaskCatException(
                 f"Invalid parameter {param_dict} all items must "
                 f"have both ParameterKey and ParameterValue keys"
@@ -228,6 +233,7 @@ def fetch_secretsmanager_parameter_value(boto_client, secret_arn):
     try:
         response = secrets_manager.get_secret_value(SecretId=secret_arn)["SecretString"]
     except Exception as e:
+        # pylint: disable=raise-missing-from
         raise TaskCatException(
             "ARN: {} encountered an error: {}".format(secret_arn, str(e))
         )

--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -142,6 +142,7 @@ class Config:
             except Exception as e:  # pylint: disable=broad-except
                 LOG.debug(str(e), exc_info=True)
                 if not template_file:
+                    # pylint: disable=raise-missing-from
                     raise error
 
     @staticmethod

--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -160,7 +160,7 @@ class AzIdField(FieldEncoder):
         return {
             "type": "string",
             "pattern": r"^((ap|eu|us|sa|ca|cn|af|me)(n|s|e|w|c|ne|se|nw|sw)"
-            r"[0-9]-az[0-9]|usw2-lax1-az1)$",
+            r"[0-9]-az[0-9]|usw2-lax1-az(1|2))$",
             "description": "Availability Zone ID, eg.: 'use1-az1'",
         }
 

--- a/taskcat/_s3_sync.py
+++ b/taskcat/_s3_sync.py
@@ -221,5 +221,6 @@ class S3Sync:
                 if retry == 5 or (
                     isinstance(e, S3UploadFailedError) and "(AccessDenied)" in str(e)
                 ):
+                    # pylint: disable=raise-missing-from
                     raise TaskCatException("Failed to upload to S3")
                 time.sleep(retry * 2)

--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -76,7 +76,7 @@
                     "description": "List of Availablilty Zones ID's to exclude when generating availability zones",
                     "items": {
                         "description": "Availability Zone ID, eg.: 'use1-az1'",
-                        "pattern": "^((ap|eu|us|sa|ca|cn|af|me)(n|s|e|w|c|ne|se|nw|sw)[0-9]-az[0-9]|usw2-lax1-az1)$",
+                        "pattern": "^((ap|eu|us|sa|ca|cn|af|me)(n|s|e|w|c|ne|se|nw|sw)[0-9]-az[0-9]|usw2-lax1-az(1|2))$",
                         "type": "string"
                     },
                     "type": "array"
@@ -200,7 +200,7 @@
                     "description": "List of Availablilty Zones ID's to exclude when generating availability zones",
                     "items": {
                         "description": "Availability Zone ID, eg.: 'use1-az1'",
-                        "pattern": "^((ap|eu|us|sa|ca|cn|af|me)(n|s|e|w|c|ne|se|nw|sw)[0-9]-az[0-9]|usw2-lax1-az1)$",
+                        "pattern": "^((ap|eu|us|sa|ca|cn|af|me)(n|s|e|w|c|ne|se|nw|sw)[0-9]-az[0-9]|usw2-lax1-az(1|2))$",
                         "type": "string"
                     },
                     "type": "array"

--- a/tests/test_cfn_lint.py
+++ b/tests/test_cfn_lint.py
@@ -193,7 +193,7 @@ class TestCfnLint(unittest.TestCase):
             lint.output_results()
             self.assertTrue(
                 mock_log_info.call_args[0][0].startswith(
-                    "Lint passed for test test1 on template "
+                    f"Linting passed for file: {str(templates['test1'].template_path)}"
                 )
             )
             self.assertEqual(mock_log_error.called, False)
@@ -211,8 +211,8 @@ class TestCfnLint(unittest.TestCase):
             test.append(rule)
             lint.output_results()
             self.assertTrue(
-                mock_log_warning.call_args_list[0][0][0].startswith(
-                    "Lint detected issues for test test1 on template "
+                mock_log_warning.call_args_list[1][0][0].startswith(
+                    f"Linting detected issues in: {str(templates['test1'].template_path)}"
                 )
             )
             mock_log_warning.assert_has_calls(
@@ -232,7 +232,7 @@ class TestCfnLint(unittest.TestCase):
             lint.output_results()
             self.assertTrue(
                 mock_log_warning.call_args[0][0].startswith(
-                    "Lint detected issues for test test1 on template "
+                    f"Linting detected issues in: {str(templates['test1'].template_path)}"
                 )
             )
             mock_log_error.assert_called_once_with(


### PR DESCRIPTION
## Overview

This PR...
- Addresses a race condition where an out-of-band action against a stack could result in a successful test (Issue #195 - originally marked as wontfix, now fixed)
- Identifies a `DELETE_FAILED` status as a stack failure. (#531)
- Improves how linting errors are displayed to the end user. (screenshot attached)
- also adds support for the new LAX local zone.
_plus unit tests_
![Screen Shot 2020-08-11 at 12 51 36 PM](https://user-images.githubusercontent.com/29951057/89944158-fa80e880-dbe4-11ea-85e3-da189e1f3e47.png)

