### PR TITLE
add missing argument to constructor

### DIFF
--- a/taskcat/_amiupdater.py
+++ b/taskcat/_amiupdater.py
@@ -334,6 +334,7 @@ class AMIUpdater:
                 profile=profile,
                 _boto3_cache=self.boto3_cache,
                 taskcat_id=self.config.uid,
+                _role_name=None,
             )
         return regions
 


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed (use case)?

Currently runnig the command:
```bash
taskcat update-ami
```
under python 3.6 fails with an exception.
Complaining that the constructor of the dataclass RegionObj is missing a value.

## Testing/Steps taken to ensure quality

I run the same command before the fix and after the fix to make sure it is running. this change only affect update-ami.

## Testing Instructions
 I have not changed or created a test case for this as I assumed there is a reason why it was not tested as part of data classes.
