### PR TITLE
disable boto3 s3 threading

### DIFF
--- a/taskcat/_s3_sync.py
+++ b/taskcat/_s3_sync.py
@@ -8,6 +8,7 @@ from multiprocessing.dummy import Pool as ThreadPool
 from typing import List
 
 from boto3.exceptions import S3UploadFailedError
+from boto3.s3.transfer import TransferConfig
 
 from taskcat._logger import PrintMsg
 from taskcat.exceptions import TaskCatException
@@ -210,7 +211,11 @@ class S3Sync:
             )
             try:
                 s3_client.upload_file(
-                    local_filename, bucket, prefix + s3_path, ExtraArgs={"ACL": acl}
+                    local_filename,
+                    bucket,
+                    prefix + s3_path,
+                    ExtraArgs={"ACL": acl},
+                    Config=TransferConfig(use_threads=False),
                 )
                 break
             except Exception as e:  # pylint: disable=broad-except

--- a/tests/test_amiupdater.py
+++ b/tests/test_amiupdater.py
@@ -850,7 +850,7 @@ class TestAMIUpdater(unittest.TestCase):
         b = APIResultsData(**instance_args)
 
         with self.assertRaises(TypeError):
-            a < b
+            a < b  # noqa: B015
 
     def test_APIResults_greaterthan_comparison_standard(self):
         from taskcat._amiupdater import APIResultsData
@@ -870,7 +870,7 @@ class TestAMIUpdater(unittest.TestCase):
         b = APIResultsData(**instance_args)
 
         with self.assertRaises(TypeError):
-            a > b
+            a > b  # noqa: B015
 
     def test_APIResults_lessthan_comparison_custom(self):
         from taskcat._amiupdater import APIResultsData


### PR DESCRIPTION
## Overview

When taskcat's s3 uploading was created boto3 only did single threaded uploads. Adding boto3/s3transfer's threading implementation on top of what's in taskcat results in waay too many threads being spawned for a big project with many regions. 

Ultimately we should evaluate the s3transfer implementation and use that instead of our own threads, for now though this fixes the implementation for large projects.

## Testing/Steps taken to ensure quality

tested upload of eks quickstart, which prior to this patch crashed my macbook.