### PR TITLE
Adding regions to global config

### DIFF
--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -429,6 +429,7 @@ class GeneralConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ign
     s3_regional_buckets: Optional[bool] = field(
         default=None, metadata=METADATA["s3_regional_buckets"]
     )
+    regions: Optional[List[Region]] = field(default=None, metadata=METADATA["regions"])
 
 
 @dataclass

--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -43,6 +43,15 @@
                     "description": "Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence",
                     "type": "object"
                 },
+                "regions": {
+                    "description": "List of AWS regions",
+                    "items": {
+                        "description": "AWS Region name eg.: 'us-east-1'",
+                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "s3_bucket": {
                     "description": "Name of S3 bucket to upload project to, if left out a bucket will be auto-generated",
                     "type": "string"
@@ -280,6 +289,7 @@
             "default": {
                 "auth": null,
                 "parameters": null,
+                "regions": null,
                 "s3_bucket": null,
                 "s3_regional_buckets": null,
                 "tags": null


### PR DESCRIPTION
A super simple PR to add support for regions in the global/general config. 

Use case is situations where the regions defined in the project config wish to be unilatery overwritten. I don't expect that this will gander much use, however edge cases have cropped up where this will be very useful.

pre-commit hooks ran, unit tests ran.