### PR TITLE
Adding key_prefix and dry_run to upload subcommand

### DIFF
--- a/taskcat/_cli_core.py
+++ b/taskcat/_cli_core.py
@@ -77,9 +77,8 @@ class CliCore:
     def longform_param_required(cls, param_name):
         def wrapper(command_func):
             formatted_param = param_name.lower().replace("_", "-")
-            cls.longform_required.append(
-                f"{command_func.__qualname__}.{formatted_param}"
-            )
+            qualname = command_func.__qualname__.replace(".__init__", "")
+            cls.longform_required.append(f"{qualname}.{formatted_param}")
             return command_func
 
         return wrapper

--- a/taskcat/_cli_modules/upload.py
+++ b/taskcat/_cli_modules/upload.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict
 
+from taskcat._cli_core import CliCore
 from taskcat._client_factory import Boto3Cache
 from taskcat._config import Config
 from taskcat._lambda_build import LambdaBuild
@@ -15,6 +16,7 @@ class Upload:
     Uploads project to S3.
     """
 
+    @CliCore.longform_param_required("dry_run")
     def __init__(
         self,
         config_file: str = "./.taskcat.yml",
@@ -22,6 +24,8 @@ class Upload:
         enable_sig_v2: bool = False,
         bucket_name: str = "",
         disable_lambda_packaging: bool = False,
+        key_prefix: str = "",
+        dry_run: bool = False,
     ):
         """does lambda packaging and uploads to s3
 
@@ -30,12 +34,17 @@ class Upload:
         :param bucket_name: set bucket name instead of generating it. If regional
         buckets are enabled, will use this as a prefix
         :param disable_lambda_packaging: skip packaging step
+        :param key_prefix: provide a custom key-prefix for uploading to S3. This
+        will be used instead of `project` => `name` in the config
+        :param dry_run: identify changes needed but do not upload to S3.
         """
         project_root_path: Path = Path(project_root).expanduser().resolve()
         input_file_path: Path = project_root_path / config_file
         args: Dict[str, Any] = {"project": {"s3_enable_sig_v2": enable_sig_v2}}
         if bucket_name:
             args["project"]["bucket_name"] = bucket_name
+        if key_prefix:
+            args["project"]["name"] = key_prefix
         config = Config.create(
             project_root=project_root_path,
             project_config_path=input_file_path,
@@ -48,4 +57,4 @@ class Upload:
         ):
             LambdaBuild(config, project_root_path)
         buckets = config.get_buckets(boto3_cache)
-        stage_in_s3(buckets, config.config.project.name, config.project_root)
+        stage_in_s3(buckets, config.config.project.name, config.project_root, dry_run)


### PR DESCRIPTION
This PR:
- Adds `--key-prefix` and `--dry-run` (longform required) to `taskcat upload` subcommand
- Fixes a bug in `CliCore.longform_param_required` that affected CLIModules that were classes (Upload, for example)
NOTE: `CliCore.longform_param_required` was not in use previously, so the bug was not encountered.


The use-case for dry-run is pretty edge, but in conjunction with `key-prefix`, it may be desirable to see the effects without uploading. 

The upload logic and logging messages have been modified to reflect this flag. All other operations - object comparision, flagging for delete, and so on, still exist.

The net-result is that the user will see what objects are being uploaded/deleted, without the upload/delete actually occuring.