### PR TITLE
hook plugin implementation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -549,7 +549,7 @@ valid-metaclass-classmethod-first-arg=cls
 max-args=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=10
+max-attributes=20
 
 # Maximum number of boolean expressions in an if statement.
 max-bool-expr=5

--- a/.pylintrc
+++ b/.pylintrc
@@ -329,7 +329,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=88
+max-line-length=140
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,3 +139,7 @@ jobs:
           condition: $RELEASE_THE_KRAKEN = true
      
   # Add Docker provider
+cache:
+  directories:
+  - $HOME/.cache/pip
+  - $HOME/.cache/pre-commit

--- a/e2e/tests/test_import.sh
+++ b/e2e/tests/test_import.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 
 EXIT_CODE=0
+SOURCE="../../taskcat/"
+OMIT="../../taskcat/_stacker.py"
+COV_CMD="coverage run -a --source ${SOURCE} --omit ${OMIT}"
 
 ${COV_CMD} -m unittest discover test_imported/ >& /tmp/output || EXIT_CODE=$?
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ exclude =
     .eggs,
     .tox
 max-complexity = 10
-max-line-length = 88
+max-line-length = 140
 select = C,E,F,W,B,B950,T001,T003
 # C812, C815, W503 clash with black
 ignore = E501,C812,C815,W503,E203

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,13 @@ with open("VERSION", "r", encoding="utf-8") as fh:
 setup(
     version=VERSION,
     name="taskcat",
-    packages=["taskcat", "taskcat._cfn", "taskcat._cli_modules", "taskcat.testing"],
+    packages=[
+        "taskcat",
+        "taskcat._cfn",
+        "taskcat._cli_modules",
+        "taskcat.testing",
+        "taskcat_plugin_testhook",
+    ],
     description="An OpenSource Cloudformation Deployment Framework",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -72,6 +72,10 @@ METADATA = {
         "description": "Shorten stack names generated for tests, set to true to enable"
     },
     "role_name": {"description": "Role name to use when launching CFN Stacks."},
+    "prehooks": {"description": "hooks to execute prior to executing tests"},
+    "posthooks": {"description": "hooks to execute after executing tests"},
+    "type": {"description": "hook type"},
+    "config": {"description": "hook configuration"},
 }
 
 # types
@@ -415,6 +419,14 @@ class TestObj:
 
 
 @dataclass
+class HookData(JsonSchemaMixin, allow_additional_props=False):  # type: ignore
+    """Hook definition"""
+
+    type: Optional[str] = field(default=None, metadata=METADATA["type"])
+    config: Optional[Dict[str, Any]] = field(default=None, metadata=METADATA["config"])
+
+
+@dataclass
 class GeneralConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ignore
     """General configuration settings."""
 
@@ -430,6 +442,12 @@ class GeneralConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ign
         default=None, metadata=METADATA["s3_regional_buckets"]
     )
     regions: Optional[List[Region]] = field(default=None, metadata=METADATA["regions"])
+    prehooks: Optional[List[HookData]] = field(
+        default=None, metadata=METADATA["prehooks"]
+    )
+    posthooks: Optional[List[HookData]] = field(
+        default=None, metadata=METADATA["posthooks"]
+    )
 
 
 @dataclass
@@ -455,6 +473,12 @@ class TestConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ignore
         default=None, metadata=METADATA["az_ids"]
     )
     role_name: Optional[str] = field(default=None, metadata=METADATA["role_name"])
+    prehooks: Optional[List[HookData]] = field(
+        default=None, metadata=METADATA["prehooks"]
+    )
+    posthooks: Optional[List[HookData]] = field(
+        default=None, metadata=METADATA["posthooks"]
+    )
 
 
 # pylint: disable=too-many-instance-attributes
@@ -506,6 +530,12 @@ class ProjectConfig(JsonSchemaMixin, allow_additional_props=False):  # type: ign
         default=None, metadata=METADATA["shorten_stack_name"]
     )
     role_name: Optional[str] = field(default=None, metadata=METADATA["role_name"])
+    prehooks: Optional[List[HookData]] = field(
+        default=None, metadata=METADATA["prehooks"]
+    )
+    posthooks: Optional[List[HookData]] = field(
+        default=None, metadata=METADATA["posthooks"]
+    )
 
 
 PROPAGATE_KEYS = ["tags", "parameters", "auth"]
@@ -515,6 +545,8 @@ PROPOGATE_ITEMS = [
     "template",
     "az_blacklist",
     "s3_regional_buckets",
+    "prehooks",
+    "posthooks",
 ]
 
 

--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -43,6 +43,20 @@
                     "description": "Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence",
                     "type": "object"
                 },
+                "posthooks": {
+                    "description": "hooks to execute after executing tests",
+                    "items": {
+                        "$ref": "#/definitions/HookData"
+                    },
+                    "type": "array"
+                },
+                "prehooks": {
+                    "description": "hooks to execute prior to executing tests",
+                    "items": {
+                        "$ref": "#/definitions/HookData"
+                    },
+                    "type": "array"
+                },
                 "regions": {
                     "description": "List of AWS regions",
                     "items": {
@@ -66,6 +80,21 @@
                     },
                     "description": "Tags to apply to CloudFormation template",
                     "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "HookData": {
+            "additionalProperties": false,
+            "description": "Hook definition",
+            "properties": {
+                "config": {
+                    "description": "hook configuration",
+                    "type": "object"
+                },
+                "type": {
+                    "description": "hook type",
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -144,6 +173,20 @@
                     },
                     "description": "Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence",
                     "type": "object"
+                },
+                "posthooks": {
+                    "description": "hooks to execute after executing tests",
+                    "items": {
+                        "$ref": "#/definitions/HookData"
+                    },
+                    "type": "array"
+                },
+                "prehooks": {
+                    "description": "hooks to execute prior to executing tests",
+                    "items": {
+                        "$ref": "#/definitions/HookData"
+                    },
+                    "type": "array"
                 },
                 "regions": {
                     "description": "List of AWS regions",
@@ -245,6 +288,20 @@
                     "description": "Parameter key-values to pass to CloudFormation, parameters provided in global config take precedence",
                     "type": "object"
                 },
+                "posthooks": {
+                    "description": "hooks to execute after executing tests",
+                    "items": {
+                        "$ref": "#/definitions/HookData"
+                    },
+                    "type": "array"
+                },
+                "prehooks": {
+                    "description": "hooks to execute prior to executing tests",
+                    "items": {
+                        "$ref": "#/definitions/HookData"
+                    },
+                    "type": "array"
+                },
                 "regions": {
                     "description": "List of AWS regions",
                     "items": {
@@ -289,6 +346,8 @@
             "default": {
                 "auth": null,
                 "parameters": null,
+                "posthooks": null,
+                "prehooks": null,
                 "regions": null,
                 "s3_bucket": null,
                 "s3_regional_buckets": null,
@@ -307,6 +366,8 @@
                 "owner": null,
                 "package_lambda": null,
                 "parameters": null,
+                "posthooks": null,
+                "prehooks": null,
                 "regions": null,
                 "role_name": null,
                 "s3_bucket": null,

--- a/taskcat/testing/_hooks.py
+++ b/taskcat/testing/_hooks.py
@@ -1,0 +1,41 @@
+import logging
+from importlib import import_module
+from typing import Mapping, Optional
+
+from taskcat._config import Config
+from taskcat._dataclasses import TestObj
+from taskcat.exceptions import TaskCatException
+
+LOG = logging.getLogger(__name__)
+
+
+def execute_hooks(
+    stage: str, config: Config, tests: Mapping[str, TestObj], parameters, outputs=None,
+):
+    prehook_failures = []
+    for name, test in config.config.tests.items():
+        if getattr(test, stage):
+            for hook in getattr(test, stage):
+                try:
+                    plugin = import_module(f"taskcat_plugin_{hook.type}")
+                except ModuleNotFoundError as e:
+                    raise TaskCatException(f'hook "{hook.type}" not found') from e
+                try:
+                    LOG.info(f"Executing {stage[:-1]} {hook.type} for test {name}")
+                    plugin.Hook(hook.config, config, tests[name], parameters, outputs)  # type: ignore
+                except TaskCatException as e:
+                    prehook_failures.append((hook.type, name, str(e)))
+    if prehook_failures:
+        raise TaskCatException(f"One or more hooks failed {prehook_failures}")
+
+
+class BaseTaskcatHook:
+    def __init__(
+        self,
+        hook_config: dict,
+        config: Config,
+        test: TestObj,
+        parameters: dict,
+        outputs: Optional[dict],
+    ):
+        pass

--- a/taskcat/testing/_hooks.py
+++ b/taskcat/testing/_hooks.py
@@ -16,6 +16,7 @@ def execute_hooks(
     for name, test in config.config.tests.items():
         if getattr(test, stage):
             for hook in getattr(test, stage):
+                LOG.warning(f"{stage} is alpha functionality, use with caution.")
                 try:
                     plugin = import_module(f"taskcat_plugin_{hook.type}")
                 except ModuleNotFoundError as e:

--- a/taskcat_plugin_testhook/__init__.py
+++ b/taskcat_plugin_testhook/__init__.py
@@ -1,0 +1,20 @@
+from typing import Mapping, Optional
+
+from taskcat._config import Config
+from taskcat._dataclasses import TestObj
+from taskcat.exceptions import TaskCatException
+from taskcat.testing._hooks import BaseTaskcatHook
+
+
+class Hook(BaseTaskcatHook):
+    def __init__(
+        self,
+        hook_config: dict,
+        config: Config,
+        tests: Mapping[str, TestObj],
+        parameters: dict,
+        outputs: Optional[dict],
+    ):
+        super().__init__(hook_config, config, tests, parameters, outputs)
+        if hook_config.get("generate_failure"):
+            raise TaskCatException("generated failure from hook")

--- a/tests/data/hook_plugin/.taskcat.yml
+++ b/tests/data/hook_plugin/.taskcat.yml
@@ -5,6 +5,7 @@ project:
   regions:
   - us-east-1
   - us-west-2
+  s3_bucket: test-bucket
 tests:
   hook-fail:
     template: templates/test.template.yaml

--- a/tests/data/hook_plugin/.taskcat.yml
+++ b/tests/data/hook_plugin/.taskcat.yml
@@ -1,0 +1,24 @@
+project:
+  name: hook
+  owner: owner@company.com
+  package_lambda: false
+  regions:
+  - us-east-1
+  - us-west-2
+tests:
+  hook-fail:
+    template: templates/test.template.yaml
+    prehooks:
+    - type: testhook
+      config:
+        generate_failure: true
+  hook-pass:
+    template: templates/test.template.yaml
+    prehooks:
+      - type: testhook
+        config:
+          generate_failure: false
+  hook-nonexist:
+    template: templates/test.template.yaml
+    prehooks:
+      - type: testhookthatdoesntexist

--- a/tests/data/hook_plugin/templates/test.template.yaml
+++ b/tests/data/hook_plugin/templates/test.template.yaml
@@ -1,0 +1,5 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  Test:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Properties: {}

--- a/tests/testing_module/test_hooks.py
+++ b/tests/testing_module/test_hooks.py
@@ -7,20 +7,25 @@ from taskcat.exceptions import TaskCatException
 from taskcat.testing import CFNTest
 
 
-class TestCFNTest(unittest.TestCase):
-    def setUp(self):
-        self.project_root_path = Path(__file__).parent / "../data/hook_plugin"
-        self.input_file_path = self.project_root_path / ".taskcat.yml"
+def get_config():
+    project_root_path = Path(__file__).parent / "../data/hook_plugin"
+    input_file_path = project_root_path / ".taskcat.yml"
+    config = Config.create(
+        project_root=project_root_path, project_config_path=input_file_path,
+    )
+    config.get_buckets = MagicMock()
+    config.get_regions = MagicMock()
+    config.get_rendered_parameters = MagicMock()
+    config.get_tests = MagicMock()
+    return config
 
+
+class TestHooks(unittest.TestCase):
     @patch("taskcat.testing._cfn_test.Stacker")
-    def test_execute_hooks_fail(self, mock_stacker: MagicMock):
-        mock_stacker.stacks.return_value = None
-        config = Config.create(
-            project_root=self.project_root_path,
-            project_config_path=self.input_file_path,
-        )
-
-        t = CFNTest(config, lint_disable=True, test_names="hook-fail")
+    @patch("taskcat.testing._cfn_test.Boto3Cache", autospec=True)
+    def test_execute_hooks_fail(self, _m_s: MagicMock, _m_bc: MagicMock):
+        config = get_config()
+        t = CFNTest(config, lint_disable=True, skip_upload=True, test_names="hook-fail")
         with self.assertRaises(TaskCatException) as exc:
             t.run()
         self.assertEqual(
@@ -29,24 +34,20 @@ class TestCFNTest(unittest.TestCase):
         )
 
     @patch("taskcat.testing._cfn_test.Stacker")
-    def test_execute_hooks_pass(self, mock_stacker: MagicMock):
-        mock_stacker.stacks.return_value = None
-        config = Config.create(
-            project_root=self.project_root_path,
-            project_config_path=self.input_file_path,
-        )
-        t = CFNTest(config, lint_disable=True, test_names="hook-pass")
+    @patch("taskcat.testing._cfn_test.Boto3Cache")
+    def test_execute_hooks_pass(self, _m_s: MagicMock, _m_bc: MagicMock):
+        config = get_config()
+        t = CFNTest(config, lint_disable=True, skip_upload=True, test_names="hook-pass")
         t.run()
         self.assertEqual(t.passed, True)
 
     @patch("taskcat.testing._cfn_test.Stacker")
-    def test_execute_hooks_nonexistant(self, mock_stacker: MagicMock):
-        mock_stacker.stacks.return_value = None
-        config = Config.create(
-            project_root=self.project_root_path,
-            project_config_path=self.input_file_path,
+    @patch("taskcat.testing._cfn_test.Boto3Cache")
+    def test_execute_hooks_nonexistant(self, _m_s: MagicMock, _m_bc: MagicMock):
+        config = get_config()
+        t = CFNTest(
+            config, lint_disable=True, skip_upload=True, test_names="hook-nonexist"
         )
-        t = CFNTest(config, lint_disable=True, test_names="hook-nonexist")
         with self.assertRaises(TaskCatException) as exc:
             t.run()
         self.assertEqual(str(exc.exception), 'hook "testhookthatdoesntexist" not found')

--- a/tests/testing_module/test_hooks.py
+++ b/tests/testing_module/test_hooks.py
@@ -1,0 +1,52 @@
+import unittest
+from pathlib import Path
+
+from mock import MagicMock, patch
+from taskcat import Config
+from taskcat.exceptions import TaskCatException
+from taskcat.testing import CFNTest
+
+
+class TestCFNTest(unittest.TestCase):
+    def setUp(self):
+        self.project_root_path = Path(__file__).parent / "../data/hook_plugin"
+        self.input_file_path = self.project_root_path / ".taskcat.yml"
+
+    @patch("taskcat.testing._cfn_test.Stacker")
+    def test_execute_hooks_fail(self, mock_stacker: MagicMock):
+        mock_stacker.stacks.return_value = None
+        config = Config.create(
+            project_root=self.project_root_path,
+            project_config_path=self.input_file_path,
+        )
+
+        t = CFNTest(config, lint_disable=True, test_names="hook-fail")
+        with self.assertRaises(TaskCatException) as exc:
+            t.run()
+        self.assertEqual(
+            str(exc.exception),
+            "One or more hooks failed [('testhook', 'hook-fail', 'generated failure from hook')]",
+        )
+
+    @patch("taskcat.testing._cfn_test.Stacker")
+    def test_execute_hooks_pass(self, mock_stacker: MagicMock):
+        mock_stacker.stacks.return_value = None
+        config = Config.create(
+            project_root=self.project_root_path,
+            project_config_path=self.input_file_path,
+        )
+        t = CFNTest(config, lint_disable=True, test_names="hook-pass")
+        t.run()
+        self.assertEqual(t.passed, True)
+
+    @patch("taskcat.testing._cfn_test.Stacker")
+    def test_execute_hooks_nonexistant(self, mock_stacker: MagicMock):
+        mock_stacker.stacks.return_value = None
+        config = Config.create(
+            project_root=self.project_root_path,
+            project_config_path=self.input_file_path,
+        )
+        t = CFNTest(config, lint_disable=True, test_names="hook-nonexist")
+        with self.assertRaises(TaskCatException) as exc:
+            t.run()
+        self.assertEqual(str(exc.exception), 'hook "testhookthatdoesntexist" not found')


### PR DESCRIPTION
## Overview

This PR adds a pluggable way to add hooks that run before or after stacks are launched. Plugins receive test definitions, taskcat config object and rendered parameters, with stack outputs coming in a future pr.

example project config using plugins:

```
tests:
  foobar:
    prehooks:
    - type: cfn-lint
      config:
        strict: true
        custom-resource-spec: ./my-resource-spec.json
    posthooks:
    - type: run-command
      config:
        command: touch blah
        timeout: 100
```

plugins must be installed using the `type` prefixed with `taskcat_plugin_` as package name, and `Hook` as class name. These can be bundled into taskcat when it installs, or installed separately from a plugin owned and published by 3rd parties.

