### PR TITLE
lambda build should ignore files and only process directories

### DIFF
--- a/taskcat/_lambda_build.py
+++ b/taskcat/_lambda_build.py
@@ -56,6 +56,9 @@ class LambdaBuild:
         if not parent_path.is_dir():
             return
         for path in parent_path.iterdir():
+            if path.is_file():
+                LOG.warning(f"{path} is a file, not a directory, cannot package...")
+                continue
             if (path / "Dockerfile").is_file():
                 tag = f"taskcat-build-{uuid5(self.NULL_UUID, str(path)).hex}"
                 LOG.info(


### PR DESCRIPTION
Seeing this failure when a nested submodule contains a file in `<submodule_path>/functions/source/`. It is only expecting directories there.
