### PR TITLE
Migrate travis-ci URL in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # taskcat
-[![Build Status](https://travis-ci.org/aws-quickstart/taskcat.svg?branch=main)](https://travis-ci.org/aws-quickstart/taskcat)
+[![Build Status](https://travis-ci.com/aws-quickstart/taskcat.svg?branch=main)](https://travis-ci.com/aws-quickstart/taskcat)
 [![PyPI version](https://badge.fury.io/py/taskcat.svg)](https://badge.fury.io/py/taskcat)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
Build was moved to travis-ci.com. Update the badge URLs accordingly.
