### PR TITLE
Add amiupdater support for RHEL 8 with HA images

### DIFF
--- a/taskcat/cfg/amiupdater.cfg.yml
+++ b/taskcat/cfg/amiupdater.cfg.yml
@@ -54,6 +54,12 @@ global:
       name: RHEL-7.6_HVM-????????-arm64-?-Hourly2-GP2
       owner-id: '309956199498'
       architecture: arm64
+    RHELHA83HVM:
+      name: RHEL_HA-8.3_HVM-????????-x86_64-?-Hourly2-GP2
+      owner-id: '309956199498'
+    RHELHA84HVM:
+      name: RHEL_HA-8.4.0_HVM-????????-x86_64-?-Hourly2-GP2
+      owner-id: '309956199498'
     SLES11SP3HVM:
       name: suse-sles-11-sp3-v????????-hvm-ssd-x86_64
       owner-alias: amazon


### PR DESCRIPTION
Signed-off-by: David Duncan <davdunc@amazon.com>

## Overview

This adds support in the AMI Configurator for RHEL 8.3 with High Availability and RHEL 8.4 with High Availability  so that the images can be updated when new images are released. 
## Testing/Steps taken to ensure quality

Images IDs were matched using the filters in aws cli calls to confirm that they provide the desired results. 

How did you validate the changes in this PR?
By verifying that the filters are valid and return the intended results. 
```bash
$ aws ec2 describe-images --filters "Name=name,Values=RHEL_HA-8.3_HVM-????????-x86_64-?-Hourly2-GP2" "Name=owner-id,Values=309956199498" --region us-east-1 --query 'Images[].{Name:Name,AMI:ImageId}'
[
    {
        "Name": "RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
        "AMI": "ami-03e95cf9553d62e4e"
    }
]

$ aws ec2 describe-images --filters "Name=name,Values=RHEL_HA-8.4.0_HVM-????????-x86_64-?-Hourly2-GP2" "Name=owner-id,Values=309956199498" --region us-east-1 --query 'Images[].{Name:Name,AMI:ImageId}'
[
    {
        "Name": "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
        "AMI": "ami-02e0bb36c61bb9715"
    }
]
```

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output
see the validated changes above, but a use in mappings would look like the following: 
```yaml
Mappings:
  RHELHA8AMIS:
    us-east-1:
      RHELHA83HVM: ami-0000000000000000
      RHELHA84HVM: ami-0000000000000000
```