### PR TITLE
Making argument errors spit out help text

### DIFF
--- a/taskcat/_cli_core.py
+++ b/taskcat/_cli_core.py
@@ -13,6 +13,12 @@ from taskcat._common_utils import exit_with_code
 
 LOG = logging.getLogger(__name__)
 
+class CustomParser(argparse.ArgumentParser):
+    def error(self, message):
+        sys.stderr.write('error: %s\n' % message)
+        self.print_help()
+        sys.exit(2)
+
 
 def _get_log_level(args, exit_func=exit_with_code):
     log_level = "INFO"
@@ -198,7 +204,7 @@ class CliCore:
         return sub
 
     def _build_parser(self, description, version):
-        parser = argparse.ArgumentParser(
+        parser = CustomParser(
             description=description,
             usage=self._build_usage(),
             formatter_class=argparse.RawDescriptionHelpFormatter,


### PR DESCRIPTION
## Before
```
❯ taskcat test
 _            _             _
| |_ __ _ ___| | _____ __ _| |_
| __/ _` / __| |/ / __/ _` | __|
| || (_| \__ \   < (_| (_| | |_
 \__\__,_|___/_|\_\___\__,_|\__|



version 0.9.23
usage: taskcat [args] test [args] [subcommand] [args]
taskcat [args] <command> [args] [subcommand] [args] test: error: the following arguments are required:
```

## After

```
❯ taskcat test
 _            _             _
| |_ __ _ ___| | _____ __ _| |_
| __/ _` / __| |/ / __/ _` | __|
| || (_| \__ \   < (_| (_| | |_
 \__\__,_|___/_|\_\___\__,_|\__|



version 0.9.23
error: the following arguments are required:
usage: taskcat [args] test [args] [subcommand] [args]

Performs functional tests on CloudFormation templates.

optional arguments:
  -h, --help  show this help message and exit

subcommands:
  clean - tests
  list - all commercial regions
  resume - resumes a monitoring of a previously started test run
  retry - [ALPHA] re-launches a child stack using the same parameters as previouslaunchCloudFormation template
  run - tests whether CloudFormation templates are able to successfully launch
```