### PR TITLE
Add rm=True to docker build to reduce disk usage

### DIFF
--- a/taskcat/_lambda_build.py
+++ b/taskcat/_lambda_build.py
@@ -178,7 +178,7 @@ class LambdaBuild:
     def _docker_build(path, tag):
         cli = APIClient()
         build_logs = []
-        for line in cli.build(path=str(path), tag=tag):
+        for line in cli.build(path=str(path), tag=tag, rm=True):
             build_logs.append(line)
         output = []
         for line in build_logs:


### PR DESCRIPTION
## Summary
Add `rm=True` parameter to `docker.APIClient().build()` to automatically remove intermediate containers after each layer is created.

## Problem
Currently, TaskCat leaves intermediate containers after Docker builds, consuming significant disk space:
- ~225MB of intermediate containers per build
- Containers accumulate across multiple builds
- Problematic in disk-constrained environments (e.g., AWS CloudShell with 1GB limit)

## Solution
Set `rm=True` in the `build()` method to remove intermediate containers immediately after each layer image is created.

## Benefits
- **Reduces disk usage by ~30%** (from 740MB to 515MB in test case)
- Prevents container accumulation across multiple builds
- Layer images are still preserved (no loss of functionality)
- Better user experience in resource-constrained environments

## Testing
Tested on AWS CloudShell (1GB disk limit) building a Go Lambda function (cfn-ecr-aws-soci-index-builder) with the following results:

**Before (rm=False):**