### PR TITLE
fix(#798): Honor DOCKER_HOST environment variable for Docker API client

### DIFF
--- a/taskcat/_lambda_build.py
+++ b/taskcat/_lambda_build.py
@@ -176,7 +176,7 @@ class LambdaBuild:
 
     @staticmethod
     def _docker_build(path, tag):
-        cli = APIClient()
+        cli = APIClient(os.environ.get('DOCKER_HOST', 'unix://var/run/docker.sock')))
         build_logs = []
         for line in cli.build(path=str(path), tag=tag):
             build_logs.append(line)

--- a/taskcat/_lambda_build.py
+++ b/taskcat/_lambda_build.py
@@ -176,7 +176,7 @@ class LambdaBuild:
 
     @staticmethod
     def _docker_build(path, tag):
-        cli = APIClient(os.environ.get('DOCKER_HOST', 'unix://var/run/docker.sock')))
+        cli = APIClient(os.environ.get('DOCKER_HOST', 'unix://var/run/docker.sock'))
         build_logs = []
         for line in cli.build(path=str(path), tag=tag):
             build_logs.append(line)


### PR DESCRIPTION
## Overview

TaskCat fails when running in Kubernetes with contained runtime or in GitLab pipeline due to Docker daemon connection errors.

## Testing/Steps taken to ensure quality

See issue #798. As long as the UNIX socket is not available, the error happens.

## Solution

Allow users to specify a custom Docker host via the `DOCKER_HOST` environment variable, which is passed to the Docker APIClient constructor. 

## Changes

- Docker APIClient now uses `DOCKER_HOST` if set, otherwise defaults to `unix://var/run/docker.sock`


## Testing Instructions

Test in an environment that the Docker daemon's UNIX socket is not accessible by the client, for example in a GitLab pipleine with docker:dind service.
